### PR TITLE
Fix do4 parsing for empty event number

### DIFF
--- a/results.py
+++ b/results.py
@@ -200,7 +200,7 @@ class Heat:
         if not re.match(r'^[0-9A-F]{16}$', lines[-1]):
             raise FileParseError("", "EOF checksum not found")
         # Extract the event & heat from the header
-        match = re.match(r'^([^;]+);(\d+);1;.+$', lines[0])
+        match = re.match(r'^([^;]*);(\d+);1;.+$', lines[0])
         if not match:
             raise FileParseError("", "Unable to parse header")
         self.event = match.group(1)

--- a/results_test.py
+++ b/results_test.py
@@ -43,6 +43,31 @@ F679E29E3D8A4CC4""".split("\n")
     assert res.lanes[0].is_empty()
     assert not res.lanes[3].is_empty()
 
+def test_parse_do4_empty_event():
+    """Handle empty event #s that happen when event list is empty/exhausted"""
+    lines = """;1;1;All
+Lane1;;353.00;
+Lane2;344.68;344.76;
+Lane3;330.82;330.61;
+Lane4;354.49;354.46;
+Lane5;341.58;341.58;
+Lane6;352.50;352.67;
+Lane7;0;0;0
+Lane8;0;0;0
+Lane9;0;0;0
+Lane10;0;0;0
+FDDEBE8AA47C716C""".split("\n")
+
+    res = results.Heat()
+    res._parse_do4(lines)  # pylint: disable=protected-access
+    assert res.event == ""
+    assert res.heat == 1
+    assert res.num_expected_times() == 2
+    assert len(res.lanes[0].times) == 1
+    assert len(res.lanes[1].times) == 2
+    assert res.lanes[6].is_empty()
+    assert not res.lanes[3].is_empty()
+
 def test_parse_scb():
     """Ensure we can parse the scb format correctly"""
     lines = """#18 BOYS 10&U 50 FLY

--- a/wahoo_results.py
+++ b/wahoo_results.py
@@ -71,9 +71,9 @@ class Do4Handler(watchdog.events.PatternMatchingEventHandler):
     def on_created(self, event):
         time.sleep(1)
         heat = results.Heat(allow_inconsistent=not self._options.get_bool("inhibit_inconsistent"))
-        heat.load_do4(event.src_path)
-        scb_filename = f"E{heat.event}.scb"
         try:
+            heat.load_do4(event.src_path)
+            scb_filename = f"E{heat.event}.scb"
             heat.load_scb(os.path.join(self._options.get_str("start_list_dir"), scb_filename))
         except results.FileParseError:
             pass


### PR DESCRIPTION
When the Dolphin exhausts the list of loaded events, it begins emitting
do4 files that have empty event numbers. An empty event number field was
unexpected by the regex used to parse the 1st line of the file,
resulting in an uncaught exception (file parse error). This patch:
- Fixes the regex to tolerate an empty event field
- Properly catches parse error exceptions so that the file watcher
  doesn't crash if a file can't be parsed.
- Adds a test for the empty event field to prevent future regressions

Signed-off-by: John Strunk <john.strunk@gmail.com>

Fixes #12 