### PR TITLE
Specify cp1252 when working w/ data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### [Unreleased]
 
+#### Fixed
+
+- :bug: The text file encoding for `scb`, `do4`, and `csv` files was left
+  unspecified, which potentially led to decoding problems when non-ASCII
+  characters were encountered. `cp1252` is now specified directly.
+
 ### [0.4.1] - 2021-04-24
 
 #### Fixed

--- a/results.py
+++ b/results.py
@@ -57,7 +57,7 @@ class Event:
 
     def from_scb(self, filename: str) -> None:
         '''Parse event information from an .scb file'''
-        with open(filename, "r") as file:
+        with open(filename, "r", encoding="cp1252") as file:
             lines = file.readlines()
         return self.from_lines(lines)
 
@@ -185,7 +185,7 @@ class Heat:
         """
         Loads event results from a CTS Dolphin *.do4 file.
         """
-        with open(filename, "r") as file:
+        with open(filename, "r", encoding="cp1252") as file:
             lines = file.readlines()
         try:
             self._parse_do4(lines)
@@ -216,7 +216,7 @@ class Heat:
         Loads event data from a CTS start list *.scb file.
         Note: Heat should be set before calling this method.
         """
-        with open(filename, "r") as file:
+        with open(filename, "r", encoding="cp1252") as file:
             lines = file.readlines()
         try:
             self._parse_scb(lines)

--- a/wahoo_results.py
+++ b/wahoo_results.py
@@ -56,7 +56,7 @@ def generate_dolphin_csv(filename: str, directory: str) -> int:
     events.sort(key=lambda e: e.event)
     csv_lines = eventlist_to_csv(events)
     outfile = os.path.join(directory, filename)
-    with open(outfile, "w") as csv:
+    with open(outfile, "w", encoding="cp1252") as csv:
         csv.writelines(csv_lines)
     return len(events)
 


### PR DESCRIPTION
When accessing `scb`, `do4`, or the Dolphin `csv`, specify cp1252 to make sure the text files are interpreted w/ typical Windows encoding. Note that this should have no effect when running on Windows platforms since cp1252 is the default encoding.

Fixes #19 