### PR TITLE
Lock the version of pipenv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '43 16 * * 5'
 
+env:
+  # https://github.com/pypa/pipenv/releases
+  PIPENV_INSTALL_VERSION: "2021.5.29"
+
 jobs:
   test:
     name: Test
@@ -40,11 +44,11 @@ jobs:
 
       - name: Install pipenv
         shell: cmd
-        run: python -m pip install --user pipenv
+        run: python -m pip install --user pipenv==${{ env.PIPENV_INSTALL_VERSION }}
 
       - name: Initialize virtual environment
         shell: cmd
-        run: pipenv install --deploy
+        run: pipenv install --deploy --no-site-packages
 
       - name: Run tests
         shell: cmd


### PR DESCRIPTION
Looks like the latest release of pipenv (2021.11.5.post0) broke the path setting, causing installed scripts not to work (pypa/pipenv#4831). This locks the version of pipenv installed in CI to a known good version.