### PR TITLE
Gracefully handle removal of untracked CC devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### [Unreleased]
 
+#### Fixed
+
+- :bug: Gracefully handle Chromecast removal messages from untracked devices
+
 #### Added
 
 - :sparkles: Application now has a startup splash screen

--- a/imagecast.py
+++ b/imagecast.py
@@ -192,7 +192,12 @@ class ImageCast: # pylint: disable=too-many-instance-attributes
             def add_cast(self, uuid, service):
                 self.update_cast(uuid, service)
             def remove_cast(self, uuid, service, cast_info):
-                del parent.devices[uuid]
+                try:
+                    del parent.devices[uuid]
+                except KeyError:
+                    # received a removal message for a CC we weren't tracking.
+                    # Ignore it.
+                    pass
                 if parent.callback_fn is not None:
                     parent.callback_fn()
             def update_cast(self, uuid, service):


### PR DESCRIPTION
Handle the case where we receive a "removal" message for a Chromecast device that we aren't tracking.

Fixes #125 
Fixes WAHOO-RESULTS-9