### PR TITLE
Properly sort events when writing the CSV

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   shortened
 - :sparkles: Added documentation for using Wahoo Results with Meet Maestro
 
+#### Fixed
+
+- :bug: Fix sorting of event numbers when writing dolphin CSV.
+
 ### [0.7.0] - 2022-06-23
 
 #### Fixed

--- a/imagecast.py
+++ b/imagecast.py
@@ -32,6 +32,8 @@ from pychromecast.error import NotConnected # type: ignore
 import sentry_sdk
 import zeroconf
 
+import wh_analytics
+
 # Dict of uuid, name, enabled
 DeviceStatus = Dict[str, Any]
 
@@ -115,6 +117,7 @@ class ImageCast: # pylint: disable=too-many-instance-attributes
                     self._publish_one(self.devices[uuid]["cast"])
                 elif previous and not enabled: # disabling: disconnect
                     self._disconnect(self.devices[uuid]["cast"])
+                wh_analytics.cc_toggle(enabled)
 
     def get_devices(self) -> List[DeviceStatus]:
         '''

--- a/results.py
+++ b/results.py
@@ -71,6 +71,21 @@ class Event:
         self.event_desc = match.group(2)
         self.num_heats = (len(lines)-1)//10
 
+    def event_number_portion(self) -> int:
+        """Return the leading numeric portion of the event number"""
+        match = re.match(r'^(\d+)(\w*)$', self.event_num)
+        if not match:
+            return 0
+        return int(match.group(1))
+
+    def event_letter_portion(self) -> str:
+        """Return the trailing alphabetic portion of the event number"""
+        match = re.match(r'^(\d+)(\w*)$', self.event_num)
+        if not match:
+            return ""
+        return match.group(2)
+
+
 
 class Lane:
     """

--- a/settings.py
+++ b/settings.py
@@ -85,11 +85,13 @@ class _StartList(ttk.LabelFrame):   # pylint: disable=too-many-ancestors
     def _handle_scb_browse(self) -> None:
         directory = filedialog.askdirectory()
         if len(directory) == 0:
+            wh_analytics.set_cts_directory(False)
             return
         directory = os.path.normpath(directory)
         self._config.set_str("start_list_dir", directory)
         self._scb_directory.set(directory)
         self._csv_status.set("") # clear status line if we change directory
+        wh_analytics.set_cts_directory(True)
 
     def _handle_write_csv(self) -> None:
         outfile = "dolphin_events.csv"
@@ -98,6 +100,7 @@ class _StartList(ttk.LabelFrame):   # pylint: disable=too-many-ancestors
             self._csv_status.set("WARNING: No events were found. Check your directory.")
         else:
             self._csv_status.set(f"Wrote {num_events} events to {outfile}")
+        wh_analytics.wrote_dolphin_csv(num_events)
 
 
 class _DolphinSettings(ttk.Labelframe):  # pylint: disable=too-many-ancestors
@@ -127,12 +130,14 @@ class _DolphinSettings(ttk.Labelframe):  # pylint: disable=too-many-ancestors
     def _handle_do4_browse(self) -> None:
         directory = filedialog.askdirectory()
         if len(directory) == 0:
+            wh_analytics.set_do4_directory(False)
             return
         directory = os.path.normpath(directory)
         self._config.set_str("dolphin_dir", directory)
         self._dolphin_directory.set(directory)
         if self._watchdir_cb is not None:
             self._watchdir_cb(directory)
+        wh_analytics.set_do4_directory(True)
 
 class _GeneralSettings(ttk.LabelFrame):  # pylint: disable=too-many-ancestors,too-many-instance-attributes
     '''Miscellaneous settings'''

--- a/wahoo_results.py
+++ b/wahoo_results.py
@@ -61,7 +61,8 @@ def generate_dolphin_csv(filename: str, directory: str) -> int:
             event = results.Event()
             event.from_scb(file.path)
             events.append(event)
-    events.sort(key=lambda e: e.event_num)
+    events.sort(key=lambda e: e.event_letter_portion())
+    events.sort(key=lambda e: e.event_number_portion())
     csv_lines = eventlist_to_csv(events)
     outfile = os.path.join(directory, filename)
     with open(outfile, "w", encoding="cp1252") as csv:

--- a/wh_analytics.py
+++ b/wh_analytics.py
@@ -60,6 +60,8 @@ def application_stop(config: WahooConfig) -> None:
         "lane_count": config.get_int("num_lanes"),
         "inhibit": config.get_bool("inhibit_inconsistent"),
         "bg_image": config.get_str("image_bg") != "",
+        "normal_font": config.get_str("normal_font"),
+        "time_font": config.get_str("time_font"),
     })
     analytics.shutdown()
 
@@ -92,6 +94,30 @@ def documentation_link() -> None:
 def update_link() -> None:
     """Follow link to dl latest version event"""
     _send_event("DownloadUpdate click")
+
+def set_cts_directory(changed: bool) -> None:
+    """Set CTS start list directory"""
+    _send_event("Browse CTS directory",{
+        "directory_changed": changed,
+    })
+
+def wrote_dolphin_csv(num_events: int) -> None:
+    """Dolphin CSV event list written"""
+    _send_event("Write Dolphin CSV", {
+        "event_count": num_events,
+    })
+
+def set_do4_directory(changed: bool) -> None:
+    """Set directory to watch for do4 files"""
+    _send_event("Browse D04 directory",{
+        "directory_changed": changed,
+    })
+
+def cc_toggle(enable: bool) -> None:
+    """Enable/disable Chromecast"""
+    _send_event("Set Chromecast state",{
+        "enable": enable,
+    })
 
 def _send_event(name: str, kvparams: Dict[str, Any] = None) -> None:
     if kvparams is None:


### PR DESCRIPTION
The sorting has been done as though the events were strings, leading to a sequence like 1, 10, ..., 2.
This changes sorting to be numeric: 1, 2, 3, ..., 10, ...

It also should handle the convention of adding letter suffixes to event numbers for swim-offs and initial splits. However, it looks like Meet Manager doesn't export non-numeric event numbers anyway. 🤷‍♂️

Fixes #134 