### PR TITLE
[workflow] Update dependencies in Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -799,11 +799,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:2469240f6190aaebcb453033519eae69cfe8cc602065b4667e18ee14fc1e35dc",
-                "sha256:4fbace9a763285b608c06f01a807b51acb35f6059da6a01236654e08b0ee81ff"
+                "sha256:1b965bcdbfe52321bb1307c7c93c74035afdbfceb5f585f01a963327c5befc4e",
+                "sha256:8c648e96e0e2ec5e17ca75a28c442e2f523453fa7cf761ec093f4a656153490e"
             ],
             "index": "pypi",
-            "version": "==1.9.10"
+            "version": "==1.10.0"
         },
         "setuptools": {
             "hashes": [
@@ -934,11 +934,11 @@
         },
         "zeroconf": {
             "hashes": [
-                "sha256:430806d36002b72a45176e2e2d29856195e9286ec620dbdecd124431812a87ef",
-                "sha256:b83cff68a0c8dcd2705b5e792796239accba2bfddb09bc8d05badc642f64e7f6"
+                "sha256:0937deea8d4df905dcc5ddc387df6a12270737babbc7666e95631a3f2b147f51",
+                "sha256:629d2a0dd7a2b9af5bc5eb0c8402755e87a2d00f7015c72834fc0958ccda2835"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.39.1"
+            "version": "==0.39.2"
         },
         "zope.interface": {
             "hashes": [


### PR DESCRIPTION
This is an automated update of the `Pipfile.lock` file.

```
Package 'zeroconf' out-of-date: '==0.39.1' installed, '==0.39.2' available.
```