### PR TITLE
Fix readthedocs build by updating python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,16 +3,15 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
-# Build documentation in the docs/ directory with Sphinx
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 sphinx:
   builder: html
   configuration: docs/conf.py
-# Optionally build your docs in additional formats such as PDF
 formats:
   - pdf
-# Optionally set the version of Python and requirements required to build your
-# docs
 python:
-  # version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Due to the release of a new version of urllib, the Python version that was used to build the docs needed to be updated.

Fixes #261 