### PR TITLE
[workflow] Update dependencies in Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -878,11 +878,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
-                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
+                "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91",
+                "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==68.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==68.1.0"
         },
         "six": {
             "hashes": [
@@ -1022,58 +1022,58 @@
         },
         "zeroconf": {
             "hashes": [
-                "sha256:0166cb3a5754b759b7bf7692b9802ed92bdde755d35194b8bb938be96015a3cb",
-                "sha256:09552f47421e6e39d5e021224a58b09694db1d77803cb61689745cebb084d18b",
-                "sha256:0b63f31a4098465ac106cac15f42d99dc7462bd021a0564b34a9a44aa1772c8c",
-                "sha256:1088ea8cf74217145c3fefa67a2bca1a64120ce133308a2b88550ec1d17911c3",
-                "sha256:109e30c52065d47ec461bea9795d783595a9fcc29f37580016c49094fd9ee119",
-                "sha256:111d60f250fb6cd899679116d8ad527a66acf0066833d78b7f27b62d361b60c8",
-                "sha256:1bf4816b3df435016980abdbc3f294a82090d7df3a57d7f18321d418504d9fc3",
-                "sha256:25b448ed5f89de820410f10eb64d44443e6d4cb4c4ba3bf6e613fb928474d9a2",
-                "sha256:27383c6d6472fd29d1f19dc6aa9389b98767d2f902ea2d8b2f854c62672cd45b",
-                "sha256:28bda11c53857b2bd985a546832d7b14a8158370475a1e6907891ef1397cb308",
-                "sha256:2995ff5687829f08be6769e484f2b7be11b86003ad07bce33d12eeedc933e226",
-                "sha256:2a96c0fe9e0df0a7bbb81ac75d958e291688dc5ec7b4adb52e4e04368136d602",
-                "sha256:38611fe38e09bcf3033cabf1ebee4b351629497061ba3e047a2e0ef43090019e",
-                "sha256:3ad6f0beef76fa385335d7b871c074fd3a0fc6250b0d0f877ad6968f0cf1e031",
-                "sha256:3ae71cd76c090a4ec6d8f3f2620cd911f7fb4e92cccac60cad02b6de451868b2",
-                "sha256:43898b14cc23ce86cde3eb283ce0c173d50e2206bdcc8481df216590ddd2adc8",
-                "sha256:44f661ef7a39abc7c7b21d4301a6abf4e00723d1b285f199d4999c6e2f519bec",
-                "sha256:46ca883a1871c3c0b20d8208d8a6587719d9f3bfb82a278ee5c0e6a335c0cf8b",
-                "sha256:48931f2b196c6a38d1202a559e1d19df5f75c8a4562ec76b4502c25036e19cde",
-                "sha256:4d633499c2f049a3089aa854f1503c41626ed1536e68f683af833f5653e3f944",
-                "sha256:527743a8965e45347caa1659576c60bdc6b3a6b6185d05d610913bac8304df51",
-                "sha256:5fbe3eee137cf20c7d87da8287a9b7b03c007370467b75c62ee6ed2dbf904cdd",
-                "sha256:66dcc8be1419077504c72924035f761da16684e508908acef571e1dea7c0a3bb",
-                "sha256:6e27cf68665604f867b93f5db57bb4f0fedbc5289b7aa467f1dca1ca233305d3",
-                "sha256:6ea17419e106d95f69c6f152ace062e4a464c5f67c8f5048af6a58524df1717b",
-                "sha256:73f56e00f54f232f96ed9a9f0baf4add11629ecf4a55b3455cd0e1f1774a678c",
-                "sha256:74e46e4969841e9b6515a40529b7f1cabebb67f6208aade62233d0e708aa0bf4",
-                "sha256:775864a9386079c097ea2153bd96ade85125bcbe051b0c050822a931f6d406f9",
-                "sha256:78ff4640549d0902f90a41836e12d840f4b9f1a995a36e8d4c0844ef37689769",
-                "sha256:7df98bf0c03f57668e49e85b345f16f1d831912a67238985412df3732285091b",
-                "sha256:92e708d1a8acaa24b7c1938f4a1aeefe175292546c2d9a969a9e30c1d8d2a058",
-                "sha256:97cf86769ce983459c514b9db3276aecf710e37104386a83373882dc4dc414cf",
-                "sha256:9a226b9f82a885c3a66d9218f893594a1c409db8918cd5691041f026d9be3f3a",
-                "sha256:9ac6d62f7211d5a95f078f512712c50ff6e7577114f71fc3ae15028b6b4eaf0e",
-                "sha256:a3bd80577ec891e60ab43583435bddcb94e4df7b39248388d2f43c983a7da801",
-                "sha256:a94ef533d1fa27fdccf8bae3823f7efcd35ed1f3f0d2a477f15dabc71e2f51bb",
-                "sha256:b1e83aa4810edf5d80580fc1503050fee514be444575eab5f6f50bbbd1d52b32",
-                "sha256:bb1c6d3fa6279669cbdee1e0353d389485273709ef4e65670f98a6d1fec26398",
-                "sha256:cb574884858337b9470e92dd0f40da35a47fa9bf1a6aa42f1ea1c4d560fd3b9f",
-                "sha256:cc6302218994d0f65aacb3c63ae4b4380b64dcf211bf70f590cd42dc66952550",
-                "sha256:e1cbe11b27ac29dc58085db6b1e574329cb27152a91fedd4c6ff780090c3d98f",
-                "sha256:e58f985c715982b6b7d693dcece4fb2cf5b338e7fa7f2c0d4b3acbc69b3c99fd",
-                "sha256:e6ec6e7ab1060b5790b9942d0427cf8c32754075c22553d3d01c02b9ff1d59ae",
-                "sha256:e724ed2d5a75906adb5db7220999a43e9309b3058220079392599e4764382796",
-                "sha256:ea79c1783d8119a60adb8bd110cbf122319294f9e95539f7097c87fe1a23cb2a",
-                "sha256:f5c220332e0c3e5b9a9e3f87013a568d200828bb85fc75999d893800c9d7a9e6",
-                "sha256:f8e2c26e2ba49a49f073fa432c1f02af52e6d9fab2fa8c02c7ddff4b82f1f338",
-                "sha256:f9a9d7536cc233ca5cd5d76965781c2a8c44d6aedcf827c479ef4351f8d5ca3b",
-                "sha256:fa319fa829465ec691b2271fd1412eb29a1c88fad5ee386ab46d4be7c47d80a7"
+                "sha256:010e4334b9919581072fd0e47dba0137a48251f37b8182b161d536641d04bac2",
+                "sha256:03aecfecadcd7b6c8b618fb547e6df1792965c9598af60c0e61f96cd327cbee9",
+                "sha256:0614195eb5904c97e4b8c3ca2ec3b710ff856bf824b196991a121cfe70f0d67c",
+                "sha256:06151609299c90673037e70ab03e6272cf0ada4bf97568cb39a32e8783c6bc84",
+                "sha256:0fade43887a2ad37d1666a20b53f498426388d8ab66f5ceaa6455fabf4921efb",
+                "sha256:11b18b613e0868b802f65d5850ac815b52e15b586e8b493718581f49672c8d71",
+                "sha256:256b3584a3ede5c32efa6721de92ff0b898f2d5562de0c03afdce4776200eb97",
+                "sha256:291e9992e56f6696132a41cfb58f73d45b736cf2707a4fdf653b9bfdb6329876",
+                "sha256:2a92b39f4d896e47b760715ffc99029f655a2d4f20836667693e48be039a2db7",
+                "sha256:2c558a059f0ad8c4aab204f346ee02c860af84dfd25b3d1048520c0d6938adfc",
+                "sha256:33a9d8644b1d3eda480a63969f66094339427b81f11db24c80b695630c33f2df",
+                "sha256:39c6e78cd4f33b96d2bd2d4c18b623fbc02b1733fa4aafcfdd89682b9998f520",
+                "sha256:3a846e5f4dd5cd21aa7399f7c5c3c0029b6102191b7f46e3f1a8bf410632142a",
+                "sha256:3befafe9bfc903b8bcdd52178ccb8b3a395c2f98aa3b60619a5f37ba99d71f97",
+                "sha256:4f3fde5b0bbcce95967d51c00ce907ef59b17bfcd29e5ed8498c8733c07454ac",
+                "sha256:512a9ce69564cd437cb33be7d0739745c27fe8e932b5bdcdeb996da5c0e07f6d",
+                "sha256:59a2cee02d96be0f315edeee5808d61c02cc9251723e12e66659ac162715c074",
+                "sha256:5da026ef285c7db97baffd18757e295fe5637e036ea02baaa6ee66f72ebb3a77",
+                "sha256:5e2988f75bbcfaa13d954231cc7c80088b8ac51a9f90bacfa9c0bbdcd456b117",
+                "sha256:603d753065c9b71d85b9261d8f7b5c1bc8581312a1446144b272c352630c606e",
+                "sha256:61e21280234556d4602125c4beb5a56ce63563e1c8493b8154a3f57ea5b0197e",
+                "sha256:6c449ca12ff53b0657d28d82347e08c9a4fa16ebc553bd13f16416f47b5f1521",
+                "sha256:6d2d79bbb31e645025b0634609ec7ff9718cf2393a93c3b3a4f5b6fec1bfad09",
+                "sha256:6e5b9d56c5dfead6780452b494a0bf2962201e0538fc1cab155e0d3ee0e9187b",
+                "sha256:7058fed1ae7e3697e31be5df7f0a70b247904ae045825852efec33db2ea374a3",
+                "sha256:735b2513c3dc6fffd8f39fd76f9e586a49c3228a431a855f562a6aa0456bc4d0",
+                "sha256:7b0c990d3a17a2c90cd6254569343a68b3ea9d282aa22983f5b1766da4c7cba5",
+                "sha256:7c53dc3b2dbfb73e6c8fbcbb37d7f08fd92bd122ea8c579bb8fe17f8ba95b9dc",
+                "sha256:7d76962efbe4eaef060b9ef7185fa49418233b1d3afd229cfed5c506329e40be",
+                "sha256:839eb3af2b38a0fb4bd95a0dc96e4785dbff597f461cfd3978f82f11f42338b5",
+                "sha256:83b3265db6a4f69153c7f4b050ca903b0e395993883df3822c4694920da177f4",
+                "sha256:83b81086789b8ba3eab27311b3ae8f8732ed61f85cee0540c8e36731963ed696",
+                "sha256:8677ca21f38c6c77ced4471115ba60e1b1d5c1ff25b9f0e2b2d52a69ce96c5bc",
+                "sha256:94c23488c6e20102563913a771faf2691b221027d7ee6118758a2979acef5805",
+                "sha256:9537513bec501f1b197423f87f3d9aa00c526982a0fd7f1480ce0fd0f699d848",
+                "sha256:989877bb4625b57ea0e26ca54c495c17ed41879e40adb296d17274a281b75aee",
+                "sha256:9ae86c7c9e28c824d4511dd43eee2d5e6ab837657919a57324defa33911c358d",
+                "sha256:a24c0b02f875c6de800725734218fcda3ba7d939203b503ddcfd4e1fdf41b09e",
+                "sha256:c26829f24a28cdfe349b780de6b5a60b45562e5cd83c0a044ec0da2c63862e47",
+                "sha256:c76c1f77a086967c315ef6df8414ad5dc64436e5a31c1ca6eea6f7ddba0e042e",
+                "sha256:cbc761a79e9d115227b340bab77caf5ef531026395030ec913fcf34053d8a834",
+                "sha256:eb35d4a2f2dfd891f46d399b204449b2a5de8c6f421e227ba5742a2d95f257af",
+                "sha256:ef12724ef61e54c28f948ba424120e0df9956633b8f855fe9460ddae2fe3d3ed",
+                "sha256:ef15450c7b6b8a60a8d4ec6eb8a5fffe7c021203e898745087670dba1a39aec1",
+                "sha256:f2784aa28375cc7dd1906f566d62eaa31f0a3f5d594830072f3946b999b9d7a8",
+                "sha256:f97785697a4020b68ce45d0fdb06af7357b2c5cc836f6bc8fb79f8599bb1c02c",
+                "sha256:fa71d26c123c5e4e1468a3c4eef230ee75efbefe739d7ce469225f11f9c7a6f3",
+                "sha256:fb10eaa6938f2c0237f653f831429d848c83e23a81c50358ae9a8142b50e9565",
+                "sha256:fe77e0e5706f00f741c84600e489c850255768a97b23463bfafe1caa4ae37585"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.74.0"
+            "version": "==0.80.0"
         },
         "zope.interface": {
             "hashes": [
@@ -1544,31 +1544,36 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1fe816e26e676c1311b9e04fd576543b873576d39439f7c24c8e5c7728391ecf",
-                "sha256:2c9d570f53908cbea326ad8f96028a673b814d9dca7515bf71d95fa662c3eb6f",
-                "sha256:35b13335c6c46a386577a51f3d38b2b5d14aa619e9633bb756bd77205e4bd09f",
-                "sha256:372fd97293ed0076d52695849f59acbbb8461c4ab447858cdaeaf734a396d823",
-                "sha256:42170e68adb1603ccdc55a30068f72bcfcde2ce650188e4c1b2a93018b826735",
-                "sha256:69b32d0dedd211b80f1b7435644e1ef83033a2af2ac65adcdc87c38db68a86be",
-                "sha256:725b57a19b7408ef66a0fd9db59b5d3e528922250fb56e50bded27fea9ff28f0",
-                "sha256:769ddb6bfe55c2bd9c7d6d7020885a5ea14289619db7ee650e06b1ef0852c6f4",
-                "sha256:79c520aa24f21852206b5ff2cf746dc13020113aa73fa55af504635a96e62718",
-                "sha256:84cf9f7d8a8a22bb6a36444480f4cbf089c917a4179fbf7eea003ea931944a7f",
-                "sha256:9166186c498170e1ff478a7f540846b2169243feb95bc228d39a67a1a450cdc6",
-                "sha256:a2500ad063413bc873ae102cf655bf49889e0763b260a3a7cf544a0cbbf7e70a",
-                "sha256:a551ed0fc02455fe2c1fb0145160df8336b90ab80224739627b15ebe2b45e9dc",
-                "sha256:ad3109bec37cc33654de8db30fe8ff3a1bb57ea65144167d68185e6dced9868d",
-                "sha256:b4ea3a0241cb005b0ccdbd318fb99619b21ae51bcf1660b95fc22e0e7d3ba4a1",
-                "sha256:c36011320e452eb30bec38b9fd3ba20569dc9545d7d4540d967f3ea1fab9c374",
-                "sha256:c8a7444d6fcac7e2585b10abb91ad900a576da7af8f5cffffbff6065d9115813",
-                "sha256:cbf18f8db7e5f060d61c91e334d3b96d6bb624ddc9ee8a1cde407b737acbca2c",
-                "sha256:d145b81a8214687cfc1f85c03663a5bbe736777410e5580e54d526e7e904f564",
-                "sha256:eec5c927aa4b3e8b4781840f1550079969926d0a22ce38075f6cfcf4b13e3eb4",
-                "sha256:f3460f34b3839b9bc84ee3ed65076eb827cd99ed13ed08d723f9083cada4a212",
-                "sha256:f3940cf5845b2512b3ab95463198b0cdf87975dfd17fdcc6ce9709a9abe09e69"
+                "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315",
+                "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0",
+                "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373",
+                "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a",
+                "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161",
+                "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275",
+                "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693",
+                "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb",
+                "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65",
+                "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4",
+                "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb",
+                "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243",
+                "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14",
+                "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4",
+                "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1",
+                "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a",
+                "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160",
+                "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25",
+                "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12",
+                "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d",
+                "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92",
+                "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770",
+                "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2",
+                "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70",
+                "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb",
+                "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5",
+                "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"
             ],
             "index": "pypi",
-            "version": "==1.5.0"
+            "version": "==1.5.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1811,18 +1816,18 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
-                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
+                "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91",
+                "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==68.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==68.1.0"
         },
         "shellingham": {
             "hashes": [
-                "sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744",
-                "sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28"
+                "sha256:419c6a164770c9c7cfcaeddfacb3d31ac7a8db0b0f3e9c1287679359734107e9",
+                "sha256:cb4a6fec583535bc6da17b647dd2330cf7ef30239e05d547d99ae3705fd0f7f8"
             ],
-            "version": "==1.5.0.post1"
+            "version": "==1.5.3"
         },
         "six": {
             "hashes": [
@@ -1865,27 +1870,27 @@
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
-                "sha256:a59274de7a952a99af36b8a5092352d9249279c0e3280b7dceaae8e15873c942",
-                "sha256:c0578efa23cab5a2f3aaa8af5691b952433f4fdfaac255befd3452448e7ea4a4"
+                "sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d",
+                "sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.6"
+            "version": "==1.0.7"
         },
         "sphinxcontrib-devhelp": {
             "hashes": [
-                "sha256:4fd751c63dc40895ac8740948f26bf1a3c87e4e441cc008672abd1cb2bc8a3d1",
-                "sha256:d4e20a17f78865d4096733989b5efa0d5e7743900e98e1f6ecd6f489380febc8"
+                "sha256:63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
+                "sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.4"
+            "version": "==1.0.5"
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:14358d0f88ccf58447f2b54343cdcc0012f32de2f8d27cf934fdbc0b362f9597",
-                "sha256:abee4e6c5471203ad2fc40dc6a16ed99884a5d6b15a6f79c9269a7e82cf04149"
+                "sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
+                "sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "sphinxcontrib-jquery": {
             "hashes": [
@@ -1905,19 +1910,19 @@
         },
         "sphinxcontrib-qthelp": {
             "hashes": [
-                "sha256:962730a6ad15d21fd6760b14c9e95c00a097413595aa6ee871dd9dfa4b002a16",
-                "sha256:d31d1a1beaf3894866bb318fb712f1edc82687f1c06235a01e5b2c50c36d5c40"
+                "sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
+                "sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.5"
+            "version": "==1.0.6"
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:424164fc3a8b4355a29d5ea8b7f18199022d160c8f7b96e68bb6c50217729b87",
-                "sha256:ca31afee32e1508cff4034e258060ce2c81a3b1c49e77da60fdb61f0e7a73c22"
+                "sha256:27849e7227277333d3d32f17c138ee148a51fa01f888a41cd6d4e73bcabe2d06",
+                "sha256:aaf3026335146e688fd209b72320314b1b278320cf232e3cda198f873838511a"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.1.7"
+            "version": "==1.1.8"
         },
         "toml": {
             "hashes": [


### PR DESCRIPTION
This is an automated update of the `Pipfile.lock` file.

```
mypy==1.5.0                             |  mypy==1.5.1                                
setuptools==68.0.0;          |  setuptools==68.1.0;
shellingham==1.5.0.post1                             |  shellingham==1.5.3                                
sphinxcontrib-applehelp==1.0 |  sphinxcontrib-applehelp==1.0
sphinxcontrib-devhelp==1.0.4 |  sphinxcontrib-devhelp==1.0.5
sphinxcontrib-htmlhelp==2.0. |  sphinxcontrib-htmlhelp==2.0.
sphinxcontrib-qthelp==1.0.5; |  sphinxcontrib-qthelp==1.0.6;
sphinxcontrib-serializinghtm |  sphinxcontrib-serializinghtm
zeroconf==0.74.0;            |  zeroconf==0.80.0;
```