### PR TITLE
[workflow] Update dependencies in Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -799,22 +799,22 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:06437f0d4bb0d5f29e3d392aba69600188d4be5ad1e0a3370e581a9bf75a3081",
-                "sha256:0b2b224e9541fe9f046dd7317d05f08769c332b7e4c54d93c7f0f372dedb0b1a",
-                "sha256:302e8752c760549ed4c7a508abc86b25d46553c81989343782809e1a062a2ef9",
-                "sha256:44837a5ed9c9418ad5d502f89f28ba102e9cd172b6668bc813f21716f9273348",
-                "sha256:55dd644adc27d2a624339332755fe077c7f26971045b469ebb9732a69ce1f2ca",
-                "sha256:5906c5e79ff50fe38b2d49d37db5874e3c8010826f2362f79996d83128a8ed9b",
-                "sha256:5d32363d14aca6e5c9e9d5918ad8fb65b091b6df66740ae9de50ac3916055e43",
-                "sha256:970c701ee16788d74f3de20938520d7a0aebc7e4fff37096a48804c80d2908cf",
-                "sha256:bd39b9094a4cc003a1f911b847ab379f89059f478c0b611ba1215053e295132e",
-                "sha256:d414199ca605eeb498adc4d2ba82aedc0379dca4a7c364ff9bc9a179aa28e71b",
-                "sha256:d4af4fd9e9418e819be30f8df2a16e72fbad546a7576ac7f3653be92a6966d30",
-                "sha256:df015c47d6855b8efa0b9be706c70bf7f050a4d5ac6d37fb043fbd95157a0e25",
-                "sha256:fc361148e902949dcb953bbcb148c99fe8f8854291ad01107e4120361849fd0e"
+                "sha256:237b9a50bd3b7307d0d834c1b0eb1a6cd47d3f4c2da840802cd03ea288ae8880",
+                "sha256:25ae91d21e3ce8d874211110c2f7edd6384816fb44e06b2867afe35139e1fd1c",
+                "sha256:2b23bd6e06445699b12f525f3e92a916f2dcf45ffba441026357dea7fa46f42b",
+                "sha256:3b7b170d3491ceed33f723bbf2d5a260f8a4e23843799a3906f16ef736ef251e",
+                "sha256:4e69965e7e54de4db989289a9b971a099e626f6167a9351e9d112221fc691bc1",
+                "sha256:58e12d2c1aa428ece2281cef09bbaa6938b083bcda606db3da4e02e991a0d924",
+                "sha256:6bd26c1fa9038b26c5c044ee77e0ecb18463e957fefbaeb81a3feb419313a54e",
+                "sha256:77700b55ba41144fc64828e02afb41901b42497b8217b558e4a001f18a85f2e3",
+                "sha256:7fda70797ddec31ddfa3576cbdcc3ddbb6b3078b737a1a87ab9136af0570cd6e",
+                "sha256:839952e759fc40b5d46be319a265cf94920174d88de31657d5622b5d8d6be5cd",
+                "sha256:bb7aa97c252279da65584af0456f802bd4b2de429eb945bbc9b3d61a42a8cd16",
+                "sha256:c00c3c7eb9ad3833806e21e86dca448f46035242a680f81c3fe068ff65e79c74",
+                "sha256:c5cdd486af081bf752225b26809d2d0a85e575b80a84cde5172a05bbb1990099"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.24.1"
+            "version": "==4.24.2"
         },
         "pychromecast": {
             "hashes": [
@@ -825,30 +825,30 @@
         },
         "pyinstaller": {
             "hashes": [
-                "sha256:0df43697c4914285ecd333be968d2cd042ab9b2670124879ee87931d2344eaf5",
-                "sha256:1fde4381155f21d6354dc450dcaa338cd8a40aaacf6bd22b987b0f3e1f96f3ee",
-                "sha256:24009eba63cfdbcde6d2634e9c87f545eb67249ddf3b514e0cd3b2cdaa595828",
-                "sha256:28d9742c37e9fb518444b12f8c8ab3cb4ba212d752693c34475c08009aa21ccf",
-                "sha256:2d03419904d1c25c8968b0ad21da0e0f33d8d65716e29481b5bd83f7f342b0c5",
-                "sha256:3a331951f9744bc2379ea5d65d36f3c828eaefe2785f15039592cdc08560b262",
-                "sha256:5e446df41255e815017d96318e39f65a3eb807e74a796c7e7ff7f13b6366a2e9",
-                "sha256:78975043edeb628e23a73fb3ef0a273cda50e765f1716f75212ea3e91b09dede",
-                "sha256:7fdd319828de679f9c5e381eff998ee9b4164bf4457e7fca56946701cf002c3f",
-                "sha256:9fc27c5a853b14a90d39c252707673c7a0efec921cd817169aff3af0fca8c127",
-                "sha256:cd7d5c06f2847195a23d72ede17c60857d6f495d6f0727dc6c9bc1235f2eb79c",
-                "sha256:e5fb17de6c325d3b2b4ceaeb55130ad7100a79096490e4c5b890224406fa42f4"
+                "sha256:16cbd66b59a37f4ee59373a003608d15df180a0d9eb1a29ff3bfbfae64b23d0f",
+                "sha256:27cd64e7cc6b74c5b1066cbf47d75f940b71356166031deb9778a2579bb874c6",
+                "sha256:2c2fe9c52cb4577a3ac39626b84cf16cf30c2792f785502661286184f162ae0d",
+                "sha256:421cd24f26144f19b66d3868b49ed673176765f92fa9f7914cd2158d25b6d17e",
+                "sha256:65133ed89467edb2862036b35d7c5ebd381670412e1e4361215e289c786dd4e6",
+                "sha256:7d51734423685ab2a4324ab2981d9781b203dcae42839161a9ee98bfeaabdade",
+                "sha256:8f6dd0e797ae7efdd79226f78f35eb6a4981db16c13325e962a83395c0ec7420",
+                "sha256:aadafb6f213549a5906829bb252e586e2cf72a7fbdb5731810695e6516f0ab30",
+                "sha256:b2e1c7f5cceb5e9800927ddd51acf9cc78fbaa9e79e822c48b0ee52d9ce3c892",
+                "sha256:c63ef6133eefe36c4b2f4daf4cfea3d6412ece2ca218f77aaf967e52a95ac9b8",
+                "sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2",
+                "sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4"
             ],
             "index": "pypi",
             "markers": "python_version < '3.13' and python_version >= '3.7'",
-            "version": "==5.13.0"
+            "version": "==5.13.2"
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [
-                "sha256:0c436a4c3506020e34116a8a7ddfd854c1ad6ddca9a8cd84500bd6e69c9e68f9",
-                "sha256:3c10df14c0f71ab388dfbf1625375b087e7330d9444cbfd2b310ba027fa0cff0"
+                "sha256:318ccc316fb2b8c0bbdff2456b444bf1ce0e94cb3948a0f4dd48f6fc33d41c01",
+                "sha256:d091a52fbeed71cde0359aa9ad66288521a8441cfba163d9446606c5136c72a8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.7"
+            "version": "==2023.8"
         },
         "pyparsing": {
             "hashes": [
@@ -911,11 +911,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:3e17215d8006612e2df02b0e73115eb8376c37e3f586d8436fa41644e605074d",
-                "sha256:a99ee105384788c3f228726a88baf515fe7b5f1d2d0f215a03d194369f158df7"
+                "sha256:2e53ad63f96bb9da6570ba2e755c267e529edcf58580a2c0d2a11ef26e1e678b",
+                "sha256:7dc873b87e1faf4d00614afd1058bfa1522942f33daef8a59f90de8ed75cd10c"
             ],
             "index": "pypi",
-            "version": "==1.29.2"
+            "version": "==1.30.0"
         },
         "setuptools": {
             "hashes": [
@@ -946,7 +946,7 @@
                 "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
                 "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.4"
         },
         "watchdog": {
@@ -1065,58 +1065,69 @@
         },
         "zeroconf": {
             "hashes": [
-                "sha256:00531deb32e01e741e98ce79eafd5d886bda817a3cd1de209910f78fe07fe881",
-                "sha256:05ef4d0c607b14e8ed2de8d1222cf2bfa949c9fbb0ab3b7dbbcccfdbd28f217d",
-                "sha256:05f39fc561dda0ba247c12ef866974b9d96f08f61ffa8f47705cee1ac25eaa3a",
-                "sha256:0690713d21926994a412cfaeecf759f9c7b4ac83469dcdceea61cf8a261696d2",
-                "sha256:08202404f0549af8f452d0f154f6c8dd9f38dfd576db8cc8842784ee06f3edfc",
-                "sha256:0ac8579ec061395cbd472ec729a9bb15199dc0ed2bfc90b2b066759b5d852cda",
-                "sha256:1151451bc37aafb2db469fd07c18dbfb914b0ce6e442dafc87b15104d554101f",
-                "sha256:19bbbd2feb537cb5d75561fd90d3a520eb0b86748376a63a2497953072e825d1",
-                "sha256:1cb3758bf37f4d352587073aedb88074325d52b06f292132adbc2a349d7d9604",
-                "sha256:25c93b87613d4e1eab9e6c1546ec1111667276044abca7281be61287c15c02b9",
-                "sha256:32faa96588143b07ea7da10891c8969c0374c95ad24800ff2f39c0bb12b9794c",
-                "sha256:39e6bd1adab2cff75932e64365569642ea7f159d6ec49ba321099361a019c4f0",
-                "sha256:3b9da90b9eb72e4b6740386b9c79a58d48bed071e5287cc32dc4415f4775b727",
-                "sha256:3bdb2b5e425387da5d0352bb2c2e268c1caa7f0c955fb414bd14649399892b09",
-                "sha256:3da43aeff25c4d4b426f0927fc0eb70bb7ab0d84f06568330f4cce3a18313eb8",
-                "sha256:482170ff1069dc961f0e874719956f12483aac6b17a1e0d181451f7299231546",
-                "sha256:4890ca014b41d03a20feee77d6a8f2bea494df420d9e800a88c7d745f9f658f1",
-                "sha256:4985ff9e00192d988ae09f88e983f1ee7c004bb02d37914caed3f4eb3949813f",
-                "sha256:4bb9d782fa27227ba5c89b015341dbdbd44bb359b9f0a42388eb84eea0beb628",
-                "sha256:4fc43df613cfb08ff4ade1e0dbad7dea4b013a070f07a130c9ccde5a3f4fd6d0",
-                "sha256:555b48e088e0fd9252b3b65daa86a69db5e587cc1752b8eaf0d3f761f306d303",
-                "sha256:57ea9709c647dd2a25b3bc9b381b1f79e68bbcc6dfba4a456f7f88d633b8642a",
-                "sha256:5883f91c6602b4c7ad38e63a377d6290a41f43ae9bfa10b287448fe4b5572d43",
-                "sha256:5cbcd36cca9d60fc2a924c8af3f4c88b43931dbd02e468f9909068cc94b30fff",
-                "sha256:5e2a63d824a6c7cb960a1baf18a8e755eec69cc7ac8353c9302bddb1940b174d",
-                "sha256:5ec2181502b11798f940aebbfd5d099d5e120fceb3059541c7a418e0775b6d0a",
-                "sha256:6859fcd29c31027b954866afedac79c4735a8c7a69b9e746c60c94fae71e43b9",
-                "sha256:69cac69d84752f6f2f9d92ea3118096ff742527c4fde51f2b747ce6fea74ae1c",
-                "sha256:6e116884c4e1a85e02845750fd43b64e7068c5535a3de1bab257a7a351812f66",
-                "sha256:72aaad1237baf3f238f7399c5bc9887e7894d0693aeace2ff66c639a612c971f",
-                "sha256:7eaed77dd88b062c5a042678392764192aee5f1acdf3c82c7159a2c598a4a0ca",
-                "sha256:8f5453a21c0f50c84447e845078422daaa4d393ff18151c422fedec22abe8d56",
-                "sha256:a0c05d62fdd90f32d81ecd400b3cbb1979e0b390aeaa479c9fa6aa17faa96468",
-                "sha256:ade6d2e50df89f95d580f53aea9334fbb5a49feee47e7d735a0bd7696be386c6",
-                "sha256:b2c71ef56c28c66b9178da5defdf5b1ccf1d1880c64d14a6a3bf05b94dbec87a",
-                "sha256:b9fe92a27413ef5bb532c97610d2f7334a281e2cb5b8a0a3f93d97f805caa4ec",
-                "sha256:bc876f8128da9baf939f7f5b7b29c8b4571b04a2036b2fa2b0c82db254a78e3e",
-                "sha256:c2b3b4a46f1e039aab4f17d294f74efe791f8799ad18fd68fecde16cf0e8a251",
-                "sha256:c4331471124bed9a2b16b4d076d8f9f1ea163a2434c07663ff6b080c55a2827d",
-                "sha256:c9a714887bf9a23cba8d0c4ac5fbb84a1f6884710b5d315fd1656c95855365ad",
-                "sha256:ca7e508ee546a729f6ee791e45770346c200b9fa82229ecc22408c97b9988f2d",
-                "sha256:ca83323283b622085b3ab922c100a5cd430fbe9b3f7f7ed2eed1f3354d3555df",
-                "sha256:cbdce295096e65ab14cdd75d6bbf6a40d653055e52c3a286ce11efc7d5cb7462",
-                "sha256:da7c3b08d912352db6f020e9b50303f1c34226012f029e8fe3c14d1c326f7413",
-                "sha256:e26a49bcf0634f952f5a7bccf73ce309c20fe0b2764488c8e1735f13e31f48b7",
-                "sha256:e6cf0856a0a8daabd8f4846abd9d5c94033d20af55ff9005611d8dfcd4a2faed",
-                "sha256:e80c877657870d0c69ba35c0785854679e1bad3632f00a37ce777b5bde4d55aa",
-                "sha256:ef7902c93391841afca24897516047fab463596edb27c99e189286e7d56c1aa8",
-                "sha256:fb2ec386851b712fb11f29f2a974b56f8ec4c2a69c07274ce56c5896a1302586"
+                "sha256:00b64a8f6887ca8550a2e8093bb0618fc1dc5c539ea206e4f2785147237afc84",
+                "sha256:00fd55b1bb5fdc46ca01b996be77100f3542fbbac176ca09bdf2c7c90a5b7cc7",
+                "sha256:047799eb33a862d7b215dedad8cbe5ca513b08c5753fb7158bec31dfe73ead99",
+                "sha256:05f1a6a451e98d30c23d5aafbaa5aa65293bba38cc2b388849f82076078542bc",
+                "sha256:07fc90e6a4d05bab41fa617a5f081ed73d2d9bc350512fd8612c9cee83ee2bd8",
+                "sha256:0c3e0dc1f619eb6ac7ce7e48fb93cddcb88edcd16371dd33f5756e742e75bcb0",
+                "sha256:0fea219a6a106f92a525ddf963073ed6576a6250facc00e35f2af58c7ccfeffb",
+                "sha256:177c395c8837698994bd85ce7355ee4f781d51a0e9a18225d2ceb3b11a323c87",
+                "sha256:1ca5dfc85e25a09bdd78c7063baa24434e40a6616a8c284d22086fd1fd60c598",
+                "sha256:1e2668428fe55ce0f9c8a7f98ae1a88501be31e8e91da5d0fcfe93c072e6fb33",
+                "sha256:2293c2660afef630d457652925fcd85078eaa2e30384589d89ffd7596b1d4b1e",
+                "sha256:2c4d6715052b864f2ec3f89f4d66256b9b2932e887e46f0f24ca1d7200cf7e49",
+                "sha256:2eac559560b433844104a1d7e2e698dcb7ee24dd82011c59037fa3f661c7473e",
+                "sha256:32349e04fea46f9f5125bacb45a959bfdb273e29f9a64d46d8a5f0abde61a8fe",
+                "sha256:3c921fb7e551d889310f337c057b865d6ab0ea49a6bbda617338ff60f9bb1239",
+                "sha256:408563bbbaa03f04304352bf7488ded8da16ba95d20d086bb6faff5f0353efb8",
+                "sha256:457bda14f9458ee57f60a8fc940e904845e682316be3edb68f3842e47afc87ed",
+                "sha256:49f49e7b64e79f5de8245bc2c21e1554f350f81e234803257229daa9b44c3bcd",
+                "sha256:51c0935682039d5701235eddb5ca54523609966975d557318299841d9ce84fd3",
+                "sha256:52da495eba918ed863b98ca2247327b0570c98d0626d0b29de52ff76fd41a1d3",
+                "sha256:5aaffdb3c44b84ac75fe9f0cca8a6f354cd882bfb594337dc5ffc20f5557bed1",
+                "sha256:672c983fa0007ada87ce04de1b9de72c15e51a814cec58cad41924ccdebe1901",
+                "sha256:6cd582688be1f3bcdde0f9b28f50833a65b7de005bf6388fe003a59f2943f800",
+                "sha256:77ef9710eae6cceb82061f1dcc96d4a40948d7f702d057e84ac76b79cb189f46",
+                "sha256:789049ccd636836a81005fe514f5f289342052e9c7586bd549c44a148ac4bc0a",
+                "sha256:7b1ecbd6ad02bb43e514de04e0e6d777a0834e607c4bd2b55c09a9fce198537e",
+                "sha256:897f8545569a74d9d30b483df6156728d0cd90d8682ea86a1572bd6d09f4dae5",
+                "sha256:8cda724021977db939fb4686905972f1175db37339a83c365cdf33e157dc2bc4",
+                "sha256:9512aeeef9e4726f9566c9512b783970952e6a1a7904c0854b8ad3b9817fec6d",
+                "sha256:9b1f2113ec408b44694efe83fab736eb62c4a0fecced3872137134c14f75e04d",
+                "sha256:9b81ec8fe41b70e967e9dd4e570b3a4b0c8cb474ad6f19ec2e57dd87bd2f00b2",
+                "sha256:a1ea2dee71bd185897625d993c530842b2a43b0ccddf26737ec99f2dee1873b1",
+                "sha256:a53a07cc548e0ddb2cbf456e3bc8bb934805be11be64642c5777617e834c52e5",
+                "sha256:a5fd0cf83d2070da8c55ab96269f30d3903adc64263b5d9819e412cedf2244a8",
+                "sha256:a747e80860a0f5e297a37093f5016b3d52c461a4e68042195f037eb15dcc1816",
+                "sha256:a82579e0309d8c319e4f956a51d457c89762983ff61046974aadf3eea869e0f2",
+                "sha256:aa07657998c648381eb5432c0c32dbbd1841ac82a1462a954393131f39de9160",
+                "sha256:ab0f6dc845a8415ea2e811c3d46253b9eefd9fd8fa80c2f886e54f83590246aa",
+                "sha256:ab7e8b4aba169a7b5c04e2f97c4c6bde0766a287b9c699c7e57d4aa4153cb88b",
+                "sha256:ac80110e7e4b494f54a65acc247eee91c746cb29152a6f6ac9e1e6ed292328e3",
+                "sha256:ae556591f65b1ea96f38b43f73cd003c3d8a43c7c6529bcdef46a09122321eec",
+                "sha256:b3baa4c1a8be44fe1ce10b2d5c4be452e2c5aa428da3f3e4d327b213103a58ea",
+                "sha256:b466438b1583fedb645dcf31a1a9b5c377b4b8157cc570b0ccf73bb9799966b2",
+                "sha256:bfe5f26375731f175a0c32ba1a3122e1aa4a300951dea9afb0ab40f3776bceb1",
+                "sha256:c413a130f7ed204a6ae594fe41fcd655d26770895f9d203dbc683501796d713c",
+                "sha256:c5d95855bc7417c05c2a2d97c0a2678867191090ac04742b3bfa1385234ed1ce",
+                "sha256:c68c868bf260d229afa52d15399327b84aac8e97c8c7a57e15cffad6d4fc277e",
+                "sha256:ca99a5afc07d8988f95275d243a2a488d03dff6042dd56833d30504c218bfb89",
+                "sha256:cdbf44e2df6f860bb7a34ec2bdd08edc6aebf7ba5a27a53c74d8205c9411dcf9",
+                "sha256:cfc88e1991a9b37458015fb9091d5e1450535922670b6aa53fd7b2e81630ea53",
+                "sha256:d3c8b3da67d6c7702439a3a683c2ea8164fe663c21bfd187e8f4f509699eaf8b",
+                "sha256:d45af18ec04d305dea163f36764afa0973847ec6c1d31f165887919aeb2d1f41",
+                "sha256:d53a1c342bee19ee8557e022ebbc8f54a7de08e809a902bc30339aad7e27ee98",
+                "sha256:d94cb6c5efe6e4ce6d53727e85cda61a872506e34d7bf05e36a407b0afe19d55",
+                "sha256:d995ac875075b6f1419870717ff99cd7839c8498d8a3af3cdfb313a212b06459",
+                "sha256:e0f583aea67a076c535a9d2a3f3690d280822b7fc0d1721b23228c5fe637d6d9",
+                "sha256:e484c10c7893ddc0ebda50dcb6f296d64b74166216c6bb17e9f0aeb49c18eb6e",
+                "sha256:e769d06ad77961f46a8fa9c06958b37bb5000cbe876d9f677c6288578c09d87c",
+                "sha256:e96fb181535da79b7db2bd5a14ee462852205ef6f1060f71bf7b7782b2e45a53",
+                "sha256:ec37edd7e1fdb16a73369133d0b92ce0dc86a8cb72aed39c508465ceb42da04d"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.82.1"
+            "version": "==0.88.0"
         },
         "zope.interface": {
             "hashes": [
@@ -1418,11 +1429,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
-                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
+                "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d",
+                "sha256:f067e40ccc40f2b48395a80fcbd4728262fab54e232e090a4063ab804179efeb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.12.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.12.3"
         },
         "identify": {
             "hashes": [
@@ -1516,11 +1527,11 @@
         },
         "lsprotocol": {
             "hashes": [
-                "sha256:80aae7e39171b49025876a524937c10be2eb986f4be700ca22ee7d186b8488aa",
-                "sha256:c4f2f77712b50d065b17f9b50d2b88c480dc2ce4bbaa56eea8269dbf54bc9701"
+                "sha256:2896c5a30c34846e3d5687e35715961f49bf7b92a36e4fb2b707ff65f19087f7",
+                "sha256:d704e4e00419f74bece9795de4b34d02aa555fc0131fec49f59ac9eb46816e51"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.0.0a2"
+            "version": "==2023.0.0a3"
         },
         "markupsafe": {
             "hashes": [
@@ -1662,11 +1673,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
-                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
         },
         "pre-commit": {
             "hashes": [
@@ -1790,7 +1801,9 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
                 "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
                 "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
                 "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
                 "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
@@ -1798,7 +1811,10 @@
                 "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
                 "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
                 "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
                 "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
                 "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
                 "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
                 "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
@@ -1806,9 +1822,12 @@
                 "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
                 "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
                 "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
                 "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
                 "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
                 "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
@@ -1823,7 +1842,9 @@
                 "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
                 "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
                 "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
                 "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
                 "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
                 "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
                 "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
@@ -1899,11 +1920,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:6379ea22c49955a44ed4e62bde8c94575e9544303cc0554eaa97099ae5853a3a",
-                "sha256:ece68bb4d77b7dc090573825db45a6f9183e74098d1c21573485de250b1d1e3f"
+                "sha256:1a9290001b75c497fd087e92b0334f1bbfa1a1ae7fddc084990c4b7bd1130b88",
+                "sha256:9269f9ed2821c9ebd30e4204f5c2339f5d4980e377bc89cb2cb6f9b17409c20a"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.2.3"
+            "version": "==7.2.5"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -2065,16 +2086,16 @@
                 "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
                 "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.4"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:95a6e9398b4967fbcb5fef2acec5efaf9aa4972049d9ae41f95e0972a683fd02",
-                "sha256:e5c3b4ce817b0b328af041506a2a299418c98747c4b1e68cb7527e74ced23efc"
+                "sha256:29c70bb9b88510f6414ac3e55c8b413a1f96239b6b789ca123437d5e892190cb",
+                "sha256:772b05bfda7ed3b8ecd16021ca9716273ad9f4467c801f27e83ac73430246dca"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.24.3"
+            "version": "==20.24.4"
         },
         "wrapt": {
             "hashes": [


### PR DESCRIPTION
This is an automated update of the `Pipfile.lock` file.

```
filelock==3.12.2;            |  filelock==3.12.3;
lsprotocol==2023.0.0a2;      |  lsprotocol==2023.0.0a3;
pluggy==1.2.0;               |  pluggy==1.3.0;
protobuf==4.24.1;            |  protobuf==4.24.2;
pyinstaller-hooks-contrib==2 |  pyinstaller-hooks-contrib==2
pyinstaller==5.13.0;         |  pyinstaller==5.13.2;
sentry-sdk==1.29.2                             |  sentry-sdk==1.30.0                                
sphinx==7.2.3;               |  sphinx==7.2.5;
virtualenv==20.24.3;         |  virtualenv==20.24.4;
zeroconf==0.82.1;            |  zeroconf==0.88.0;
```