### PR TITLE
Don't join observer threads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,6 @@ jobs:
         shell: cmd
         run: wahoo-results.exe --loglevel=debug --test scripted:${{ env.TEST_DURATION_SECONDS }}
 
-
   success:
     name: Successful CI
     needs: [autotest, test]

--- a/wahoo_results.py
+++ b/wahoo_results.py
@@ -501,10 +501,10 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-locals
     logger.debug("Stopping watchers")
     scb_observer.unschedule_all()
     scb_observer.stop()
-    scb_observer.join()
-    scb_observer.unschedule_all()
+    # scb_observer.join()  # This causes an intermittent hang
+    do4_observer.unschedule_all()
     do4_observer.stop()
-    do4_observer.join()
+    # do4_observer.join()  # This causes an intermittent hang
     logger.debug("Watchers stopped")
     icast.stop()
     root.update()


### PR DESCRIPTION
- Avoids join()-ing the observer threads so the app doesn't hang on exit (shows up mainly in CI).
- Join isn't actually necessary as the threads are daemon threads and will auto-cleanup at app exit.