### PR TITLE
[workflow] Update dependencies in lockfiles

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -713,41 +713,41 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:020cdbee66ed46b671429c7265cf00d8ac91c046901c55684954c3958525dab2",
-                "sha256:0621f7daf973d34d18b4e4bafb210bbaf1ef5e0100b5fa750bd9cde84c7ac292",
-                "sha256:0792824ce2f7ea0c82ed2e4fecc29bb86bee0567a080dacaf2e0a01fe7654369",
-                "sha256:09aaee96c2cbdea95de76ecb8a586cb687d281c881f5f17bfc0fb7f5890f6b91",
-                "sha256:166b36197e9debc4e384e9c652ba60c0bacc216d0fc89e78f973a9760b503388",
-                "sha256:186ba67fad3c60dbe8a3abff3b67a91351100f2661c8e2a80364ae6279720299",
-                "sha256:306545e234503a24fe9ae95ebf84d25cba1fdc27db971aa2d9f1ab6bba19a9dd",
-                "sha256:436c8e9a4bdeeee84e3e59614d38c3dbd3235838a877af8c211cfcac8a80b8d3",
-                "sha256:4a873a8180479bc829313e8d9798d5234dfacfc2e8a7ac188418189bb8eafbd2",
-                "sha256:4acc65dd65da28060e206c8f27a573455ed724e6179941edb19f97e58161bb69",
-                "sha256:51be5f8c349fdd1a5568e72713a21f518e7d6707bcf8503b528b88d33b57dc68",
-                "sha256:546b7dd7e22f3c6861463bebb000646fa730e55df5ee4a0224408b5694cc6148",
-                "sha256:5671338034b820c8d58c81ad1dafc0ed5a00771a82fccc71d6438df00302094b",
-                "sha256:637c58b468a69869258b8ae26f4a4c6ff8abffd4a8334c830ffb63e0feefe99a",
-                "sha256:767254ad364991ccfc4d81b8152912e53e103ec192d1bb4ea6b1f5a7117040be",
-                "sha256:7d484292eaeb3e84a51432a94f53578689ffdea3f90e10c8b203a99be5af57d8",
-                "sha256:7f6bad22a791226d0a5c7c27a80a20e11cfe09ad5ef9084d4d3fc4a299cca505",
-                "sha256:86f737708b366c36b76e953c46ba5827d8c27b7a8c9d0f471810728e5a2fe57c",
-                "sha256:8c6adc33561bd1d46f81131d5352348350fc23df4d742bb246cdfca606ea1208",
-                "sha256:914b28d3215e0c721dc75db3ad6d62f51f630cb0c277e6b3bcb39519bed10bd8",
-                "sha256:b44e6a09afc12952a7d2a58ca0a2429ee0d49a4f89d83a0a11052da696440e49",
-                "sha256:bb0d9a1aaf5f1cb7967320e80690a1d7ff69f1d47ebc5a9bea013e3a21faec95",
-                "sha256:c0b45c8b65b79337dee5134d038346d30e109e9e2e9d43464a2970e5c0e93229",
-                "sha256:c2e698cb0c6dda9372ea98a0344245ee65bdc1c9dd939cceed6bb91256837896",
-                "sha256:c78a22e95182fb2e7874712433eaa610478a3caf86f28c621708d35fa4fd6e7f",
-                "sha256:e062aa24638bb5018b7841977c360d2f5917268d125c833a686b7cbabbec496c",
-                "sha256:e5e18e5b14a7560d8acf1c596688f4dfd19b4f2945b245a71e5af4ddb7422feb",
-                "sha256:eae430ecf5794cb7ae7fa3808740b015aa80747e5266153128ef055975a72b99",
-                "sha256:ee84ca3c58fe48b8ddafdeb1db87388dce2c3c3f701bf447b05e4cfcc3679112",
-                "sha256:f042f66d0b4ae6d48e70e28d487376204d3cbf43b84c03bac57e28dac6151581",
-                "sha256:f8db2f125746e44dce707dd44d4f4efeea8d7e2b43aace3f8d1f235cfa2733dd",
-                "sha256:f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"
+                "sha256:06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668",
+                "sha256:1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9",
+                "sha256:1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f",
+                "sha256:1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5",
+                "sha256:3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53",
+                "sha256:59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2",
+                "sha256:6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974",
+                "sha256:6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f",
+                "sha256:76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42",
+                "sha256:78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2",
+                "sha256:82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af",
+                "sha256:8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67",
+                "sha256:9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e",
+                "sha256:97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c",
+                "sha256:9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7",
+                "sha256:a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e",
+                "sha256:a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908",
+                "sha256:af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66",
+                "sha256:afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24",
+                "sha256:b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b",
+                "sha256:bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e",
+                "sha256:c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe",
+                "sha256:cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a",
+                "sha256:cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575",
+                "sha256:d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297",
+                "sha256:d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104",
+                "sha256:d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab",
+                "sha256:d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3",
+                "sha256:d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244",
+                "sha256:dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124",
+                "sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617",
+                "sha256:e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"
             ],
             "markers": "python_version < '3.13' and python_version >= '3.9'",
-            "version": "==1.26.0"
+            "version": "==1.26.1"
         },
         "packaging": {
             "hashes": [
@@ -767,63 +767,63 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:0462b1496505a3462d0f35dc1c4d7b54069747d65d00ef48e736acda2c8cbdff",
-                "sha256:186f7e04248103482ea6354af6d5bcedb62941ee08f7f788a1c7707bc720c66f",
-                "sha256:19e9adb3f22d4c416e7cd79b01375b17159d6990003633ff1d8377e21b7f1b21",
-                "sha256:28444cb6ad49726127d6b340217f0627abc8732f1194fd5352dec5e6a0105635",
-                "sha256:2872f2d7846cf39b3dbff64bc1104cc48c76145854256451d33c5faa55c04d1a",
-                "sha256:2cc6b86ece42a11f16f55fe8903595eff2b25e0358dec635d0a701ac9586588f",
-                "sha256:2d7e91b4379f7a76b31c2dda84ab9e20c6220488e50f7822e59dac36b0cd92b1",
-                "sha256:2fa6dd2661838c66f1a5473f3b49ab610c98a128fc08afbe81b91a1f0bf8c51d",
-                "sha256:32bec7423cdf25c9038fef614a853c9d25c07590e1a870ed471f47fb80b244db",
-                "sha256:3855447d98cced8670aaa63683808df905e956f00348732448b5a6df67ee5849",
-                "sha256:3a04359f308ebee571a3127fdb1bd01f88ba6f6fb6d087f8dd2e0d9bff43f2a7",
-                "sha256:3a0d3e54ab1df9df51b914b2233cf779a5a10dfd1ce339d0421748232cea9876",
-                "sha256:44e7e4587392953e5e251190a964675f61e4dae88d1e6edbe9f36d6243547ff3",
-                "sha256:459307cacdd4138edee3875bbe22a2492519e060660eaf378ba3b405d1c66317",
-                "sha256:4ce90f8a24e1c15465048959f1e94309dfef93af272633e8f37361b824532e91",
-                "sha256:50bd5f1ebafe9362ad622072a1d2f5850ecfa44303531ff14353a4059113b12d",
-                "sha256:522ff4ac3aaf839242c6f4e5b406634bfea002469656ae8358644fc6c4856a3b",
-                "sha256:552912dbca585b74d75279a7570dd29fa43b6d93594abb494ebb31ac19ace6bd",
-                "sha256:5d6c9049c6274c1bb565021367431ad04481ebb54872edecfcd6088d27edd6ed",
-                "sha256:697a06bdcedd473b35e50a7e7506b1d8ceb832dc238a336bd6f4f5aa91a4b500",
-                "sha256:71671503e3015da1b50bd18951e2f9daf5b6ffe36d16f1eb2c45711a301521a7",
-                "sha256:723bd25051454cea9990203405fa6b74e043ea76d4968166dfd2569b0210886a",
-                "sha256:764d2c0daf9c4d40ad12fbc0abd5da3af7f8aa11daf87e4fa1b834000f4b6b0a",
-                "sha256:787bb0169d2385a798888e1122c980c6eff26bf941a8ea79747d35d8f9210ca0",
-                "sha256:7f771e7219ff04b79e231d099c0a28ed83aa82af91fd5fa9fdb28f5b8d5addaf",
-                "sha256:847e8d1017c741c735d3cd1883fa7b03ded4f825a6e5fcb9378fd813edee995f",
-                "sha256:84efb46e8d881bb06b35d1d541aa87f574b58e87f781cbba8d200daa835b42e1",
-                "sha256:898f1d306298ff40dc1b9ca24824f0488f6f039bc0e25cfb549d3195ffa17088",
-                "sha256:8b451d6ead6e3500b6ce5c7916a43d8d8d25ad74b9102a629baccc0808c54971",
-                "sha256:8f06be50669087250f319b706decf69ca71fdecd829091a37cc89398ca4dc17a",
-                "sha256:92a23b0431941a33242b1f0ce6c88a952e09feeea9af4e8be48236a68ffe2205",
-                "sha256:93139acd8109edcdeffd85e3af8ae7d88b258b3a1e13a038f542b79b6d255c54",
-                "sha256:98533fd7fa764e5f85eebe56c8e4094db912ccbe6fbf3a58778d543cadd0db08",
-                "sha256:9f665d1e6474af9f9da5e86c2a3a2d2d6204e04d5af9c06b9d42afa6ebde3f21",
-                "sha256:b059ac2c4c7a97daafa7dc850b43b2d3667def858a4f112d1aa082e5c3d6cf7d",
-                "sha256:b1be1c872b9b5fcc229adeadbeb51422a9633abd847c0ff87dc4ef9bb184ae08",
-                "sha256:b7cf63d2c6928b51d35dfdbda6f2c1fddbe51a6bc4a9d4ee6ea0e11670dd981e",
-                "sha256:bc2e3069569ea9dbe88d6b8ea38f439a6aad8f6e7a6283a38edf61ddefb3a9bf",
-                "sha256:bcf1207e2f2385a576832af02702de104be71301c2696d0012b1b93fe34aaa5b",
-                "sha256:ca26ba5767888c84bf5a0c1a32f069e8204ce8c21d00a49c90dabeba00ce0145",
-                "sha256:cbe68deb8580462ca0d9eb56a81912f59eb4542e1ef8f987405e35a0179f4ea2",
-                "sha256:d6caf3cd38449ec3cd8a68b375e0c6fe4b6fd04edb6c9766b55ef84a6e8ddf2d",
-                "sha256:d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d",
-                "sha256:d889b53ae2f030f756e61a7bff13684dcd77e9af8b10c6048fb2c559d6ed6eaf",
-                "sha256:de596695a75496deb3b499c8c4f8e60376e0516e1a774e7bc046f0f48cd620ad",
-                "sha256:e6a90167bcca1216606223a05e2cf991bb25b14695c518bc65639463d7db722d",
-                "sha256:ed2d9c0704f2dc4fa980b99d565c0c9a543fe5101c25b3d60488b8ba80f0cce1",
-                "sha256:ee7810cf7c83fa227ba9125de6084e5e8b08c59038a7b2c9045ef4dde61663b4",
-                "sha256:f0b4b06da13275bc02adfeb82643c4a6385bd08d26f03068c2796f60d125f6f2",
-                "sha256:f11c9102c56ffb9ca87134bd025a43d2aba3f1155f508eff88f694b33a9c6d19",
-                "sha256:f5bb289bb835f9fe1a1e9300d011eef4d69661bb9b34d5e196e5e82c4cb09b37",
-                "sha256:f6d3d4c905e26354e8f9d82548475c46d8e0889538cb0657aa9c6f0872a37aa4",
-                "sha256:fcb59711009b0168d6ee0bd8fb5eb259c4ab1717b2f538bbf36bacf207ef7a68",
-                "sha256:fd2a5403a75b54661182b75ec6132437a181209b901446ee5724b589af8edef1"
+                "sha256:00f438bb841382b15d7deb9a05cc946ee0f2c352653c7aa659e75e592f6fa17d",
+                "sha256:0248f86b3ea061e67817c47ecbe82c23f9dd5d5226200eb9090b3873d3ca32de",
+                "sha256:04f6f6149f266a100374ca3cc368b67fb27c4af9f1cc8cb6306d849dcdf12616",
+                "sha256:062a1610e3bc258bff2328ec43f34244fcec972ee0717200cb1425214fe5b839",
+                "sha256:0a026c188be3b443916179f5d04548092e253beb0c3e2ee0a4e2cdad72f66099",
+                "sha256:0f7c276c05a9767e877a0b4c5050c8bee6a6d960d7f0c11ebda6b99746068c2a",
+                "sha256:1a8413794b4ad9719346cd9306118450b7b00d9a15846451549314a58ac42219",
+                "sha256:1ab05f3db77e98f93964697c8efc49c7954b08dd61cff526b7f2531a22410106",
+                "sha256:1c3ac5423c8c1da5928aa12c6e258921956757d976405e9467c5f39d1d577a4b",
+                "sha256:1c41d960babf951e01a49c9746f92c5a7e0d939d1652d7ba30f6b3090f27e412",
+                "sha256:1fafabe50a6977ac70dfe829b2d5735fd54e190ab55259ec8aea4aaea412fa0b",
+                "sha256:1fb29c07478e6c06a46b867e43b0bcdb241b44cc52be9bc25ce5944eed4648e7",
+                "sha256:24fadc71218ad2b8ffe437b54876c9382b4a29e030a05a9879f615091f42ffc2",
+                "sha256:2cdc65a46e74514ce742c2013cd4a2d12e8553e3a2563c64879f7c7e4d28bce7",
+                "sha256:2ef6721c97894a7aa77723740a09547197533146fba8355e86d6d9a4a1056b14",
+                "sha256:3b834f4b16173e5b92ab6566f0473bfb09f939ba14b23b8da1f54fa63e4b623f",
+                "sha256:3d929a19f5469b3f4df33a3df2983db070ebb2088a1e145e18facbc28cae5b27",
+                "sha256:41f67248d92a5e0a2076d3517d8d4b1e41a97e2df10eb8f93106c89107f38b57",
+                "sha256:47e5bf85b80abc03be7455c95b6d6e4896a62f6541c1f2ce77a7d2bb832af262",
+                "sha256:4d0152565c6aa6ebbfb1e5d8624140a440f2b99bf7afaafbdbf6430426497f28",
+                "sha256:50d08cd0a2ecd2a8657bd3d82c71efd5a58edb04d9308185d66c3a5a5bed9610",
+                "sha256:61f1a9d247317fa08a308daaa8ee7b3f760ab1809ca2da14ecc88ae4257d6172",
+                "sha256:6932a7652464746fcb484f7fc3618e6503d2066d853f68a4bd97193a3996e273",
+                "sha256:7a7e3daa202beb61821c06d2517428e8e7c1aab08943e92ec9e5755c2fc9ba5e",
+                "sha256:7dbaa3c7de82ef37e7708521be41db5565004258ca76945ad74a8e998c30af8d",
+                "sha256:7df5608bc38bd37ef585ae9c38c9cd46d7c81498f086915b0f97255ea60c2818",
+                "sha256:806abdd8249ba3953c33742506fe414880bad78ac25cc9a9b1c6ae97bedd573f",
+                "sha256:883f216eac8712b83a63f41b76ddfb7b2afab1b74abbb413c5df6680f071a6b9",
+                "sha256:912e3812a1dbbc834da2b32299b124b5ddcb664ed354916fd1ed6f193f0e2d01",
+                "sha256:937bdc5a7f5343d1c97dc98149a0be7eb9704e937fe3dc7140e229ae4fc572a7",
+                "sha256:9882a7451c680c12f232a422730f986a1fcd808da0fd428f08b671237237d651",
+                "sha256:9a92109192b360634a4489c0c756364c0c3a2992906752165ecb50544c251312",
+                "sha256:9d7bc666bd8c5a4225e7ac71f2f9d12466ec555e89092728ea0f5c0c2422ea80",
+                "sha256:a5f63b5a68daedc54c7c3464508d8c12075e56dcfbd42f8c1bf40169061ae666",
+                "sha256:a646e48de237d860c36e0db37ecaecaa3619e6f3e9d5319e527ccbc8151df061",
+                "sha256:a89b8312d51715b510a4fe9fc13686283f376cfd5abca8cd1c65e4c76e21081b",
+                "sha256:a92386125e9ee90381c3369f57a2a50fa9e6aa8b1cf1d9c4b200d41a7dd8e992",
+                "sha256:ae88931f93214777c7a3aa0a8f92a683f83ecde27f65a45f95f22d289a69e593",
+                "sha256:afc8eef765d948543a4775f00b7b8c079b3321d6b675dde0d02afa2ee23000b4",
+                "sha256:b0eb01ca85b2361b09480784a7931fc648ed8b7836f01fb9241141b968feb1db",
+                "sha256:b1c25762197144e211efb5f4e8ad656f36c8d214d390585d1d21281f46d556ba",
+                "sha256:b4005fee46ed9be0b8fb42be0c20e79411533d1fd58edabebc0dd24626882cfd",
+                "sha256:b920e4d028f6442bea9a75b7491c063f0b9a3972520731ed26c83e254302eb1e",
+                "sha256:baada14941c83079bf84c037e2d8b7506ce201e92e3d2fa0d1303507a8538212",
+                "sha256:bb40c011447712d2e19cc261c82655f75f32cb724788df315ed992a4d65696bb",
+                "sha256:c0949b55eb607898e28eaccb525ab104b2d86542a85c74baf3a6dc24002edec2",
+                "sha256:c9aeea7b63edb7884b031a35305629a7593272b54f429a9869a4f63a1bf04c34",
+                "sha256:cfe96560c6ce2f4c07d6647af2d0f3c54cc33289894ebd88cfbb3bcd5391e256",
+                "sha256:d27b5997bdd2eb9fb199982bb7eb6164db0426904020dc38c10203187ae2ff2f",
+                "sha256:d921bc90b1defa55c9917ca6b6b71430e4286fc9e44c55ead78ca1a9f9eba5f2",
+                "sha256:e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38",
+                "sha256:eaed6977fa73408b7b8a24e8b14e59e1668cfc0f4c40193ea7ced8e210adf996",
+                "sha256:fa1d323703cfdac2036af05191b969b910d8f115cf53093125e4058f62012c9a",
+                "sha256:fe1e26e1ffc38be097f0ba1d0d07fcade2bcfd1d023cda5b29935ae8052bd793"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.0.1"
+            "version": "==10.1.0"
         },
         "protobuf": {
             "hashes": [
@@ -853,30 +853,30 @@
         },
         "pyinstaller": {
             "hashes": [
-                "sha256:0ad7cc3776ca17d0bededcc352cba2b1c89eb4817bfabaf05972b9da8c424935",
-                "sha256:16a473065291dd7879bf596fa20e65bd9d1e8aafc2cef1bffa3e42e707e2e68e",
-                "sha256:438a9e0d72a57d5bba4f112d256e39ea4033c76c65414c0693d8311faa14b090",
-                "sha256:4a75bde5cda259bb31f2294960d75b9d5c148001b2b0bd20a91f9c2116675a6c",
-                "sha256:52e5b3a2371d7231de17515c7c78d8d4a39d70c8c095e71d55b3b83434a193a8",
-                "sha256:5314f6f08d2bcbc031778618ba97d9098d106119c2e616b3b081171fe42f5415",
-                "sha256:68769f5e6722474bb1038e35560444659db8b951388bfe0c669bb52a640cd0eb",
-                "sha256:aa922d1d73881d0820a341d2c406a571cc94630bdcdc275427c844a12e6e376e",
-                "sha256:cccdad6cfe7a5db7d7eb8df2e5678f8375268739d5933214e180da300aa54e37",
-                "sha256:d702cff041f30e7a53500b630e07b081e5328d4655023319253d73935e75ade2",
-                "sha256:d84b06fb9002109bfc542e76860b81459a8585af0bbdabcfc5dcf272ef230de7",
-                "sha256:fb6af82989dac7c58bd25ed9ba3323bc443f8c1f03804f69c9f5e363bf4a021c"
+                "sha256:041ab9311d08162356829bf47293a613c44dc9ace28846fb63098889c7383c5d",
+                "sha256:331f050e8f9e923bb6b50454acfc0547fd52092585c61eb5f2fc93de60703f13",
+                "sha256:3c04963637481a3edf1eec64ab4c3fce098908f02fc472c11e73be7eedc08b95",
+                "sha256:4368e4eb9999ce32e3280330b3c26f175e0fa7fa13efb4d2dc4ade488ff6d7c2",
+                "sha256:6e71d9f6f5a1e0f7523e8ebee1b76bb29538f64d863e3711c2b21033f499e2b9",
+                "sha256:8f3d49c60f3344bf3d4a6d4258bda665dad185ab2b097341d3af2a6387c838ef",
+                "sha256:9e8b5bbc1bdf554ade1360e62e4959091430c3cc15ebfff3c28c8894fd1f312a",
+                "sha256:bebf6f442bbe6343acaec873803510ee1930d026846a018f727da4e0690081f8",
+                "sha256:da78942d31c1911ea4abcd3ca3bd0c062af7f163a5e227fd18a359b61deda4ca",
+                "sha256:dd438afd2abb643f5399c0cb254a11c217c06782cb274a2911dd785f9f67fa9e",
+                "sha256:f63d2353537bac7bfeeaedbe5ac99f3be35daa290dd1ad1be90768acbf77e3d5",
+                "sha256:f9f5bcaef6122d93c54ee7a9ecb07eab5b81a7ebfb5cb99af2b2a6ff49eff62f"
             ],
             "index": "pypi",
             "markers": "python_version < '3.13' and python_version >= '3.8'",
-            "version": "==6.0.0"
+            "version": "==6.1.0"
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [
-                "sha256:76084b5988e3957a9df169d2a935d65500136967e710ddebf57263f1a909cd80",
-                "sha256:f34f4c6807210025c8073ebe665f422a3aa2ac5f4c7ebf4c2a26cc77bebf63b5"
+                "sha256:4b4a998036abb713774cb26534ca06b7e6e09e4c628196017a10deb11a48747f",
+                "sha256:6dc1786a8f452941245d5bb85893e2a33632ebdcbc4c23eea41f2ee08281b0c0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.9"
+            "version": "==2023.10"
         },
         "pyparsing": {
             "hashes": [
@@ -971,11 +971,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
+                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.7"
         },
         "watchdog": {
             "hashes": [
@@ -1093,69 +1093,69 @@
         },
         "zeroconf": {
             "hashes": [
-                "sha256:002340681ebe62fd6c7f67e21815d571528d27538db61110a914660e3fa1b977",
-                "sha256:00345d2455384f9385ce3fcfd32301bdcb204d48d151879e5a8ad685473b9d24",
-                "sha256:03a22b5196d8149d6cb6ba058b3a9d116546a9ba0eb5e3c459e69debfa7abeec",
-                "sha256:068dd83659a5f486026980b17287438fc6a8ed2be134090c12a5b2c6924ab89a",
-                "sha256:0703f948f24cf30c2f68e92d442ac3fec3c72c6360c2f4b588f97e1d10028a48",
-                "sha256:072f42584a978f4e108bbf1a6ae94e1a99e4977105e2e6bad25d94ac850d3c23",
-                "sha256:08364aca560d9fec5693d79b25289a8aa6fdaeef38d362439da182770da40336",
-                "sha256:093263540796fb959078d843a609aee8ab7b9c49ca9b22fd3a1631145028fea1",
-                "sha256:0e7a0c6c72cf98b2f9e8f316852519ed9f794513861e65fe9388de98eca25d40",
-                "sha256:1426124f9a91e537c0a85f15ad07fa18ef932dfa567477eb950a4e5eaac098cb",
-                "sha256:1988c41e25103ad09a3b6dbf3ee3f6a67646858e5fd37f7716bd368b616dda42",
-                "sha256:1e8e2432f10416d85ba6c47b29e1018dc2ac4325732e9f1b364266032770efd8",
-                "sha256:1ec1b4e19524776e78370539400f14f39fa3f617c81993a4fb091fed2f6523bf",
-                "sha256:23d054e49f58468411b6d544ee74306b86a2bfb05b3626eca74ae190fa0c5265",
-                "sha256:26cda47f6a143b61b5e593557f226904e38f52bf00ca49d7421d83ddbf179eae",
-                "sha256:29e5fec7e2cba7e97ded73036ca88d3230ed4c294aacc6325a76a4a379df528e",
-                "sha256:2fdf99d6899c758805a5b3e117de4b80e9895cd031c532d4a4ee795242db0498",
-                "sha256:3e75a835d30bb8999aa19ed8de5519a4815fd770bfa89f9d43307ee41540a807",
-                "sha256:4004cfca6efe1f96ada48095b023784513d232013a67e945a5bd8f24646983d1",
-                "sha256:46feb36f45527df717ddc84d0d91faa8a6e2728e9033ff0733be95417af9736f",
-                "sha256:59f7b6d607d84b8413271c2132e3f072daa874deb512db837eedf864620345b8",
-                "sha256:5ce62f971f175e7694529933edf0ddac0cd5e5b9d94a9e32da881288dc54e237",
-                "sha256:5d680cdb233557a6895432b49c6894edb194cdae7b5ca0ce10466880b1e88b62",
-                "sha256:5dfec27fcfda2e7b5ca0fc131ccab6797272ad8c7a437f5e56f07dda825c3980",
-                "sha256:5f34c479e6c57e9052d54fed2f013552a48d2cf30a957d5a53e2fac2fb757165",
-                "sha256:5faff8f372af09c0e14bf39fd38af0a0668179c7ee0e928ebcd2ffb0d1ba7a89",
-                "sha256:6885a0e56b636c5ff5c3ed4700271b52fba9b54bacdd9a9393d3f0a914826d76",
-                "sha256:69d3bdb28f0847a1dba3f094d2e4ecc3dd5f4c164b7f8f07df3694e237286134",
-                "sha256:6e86735e9d61977bac97a52cd79fdcf3e10d96337d620ae9dcded5a9809cee3a",
-                "sha256:81ab1bc4206dadf2598768fb17fa03822407d487e62e0b29deaf5e76b0f6fa1e",
-                "sha256:824fcbc56aa0f65662bb03c862fc3bbbafbb06b5e9c2b13f29a500b537fd81c4",
-                "sha256:89ae7354787e168bcca0b1caa70d0b23c3875958df1d5811859afe6f022faa96",
-                "sha256:8ea4488cb8876f12b0ebaec0e4bb78afdae73df1f084196f5d7c510608ecd2e2",
-                "sha256:94ba7633e415a62a9300bec3d94813583fabcf961e49423201125013f3502a6c",
-                "sha256:9a130188b546ba9f0929308285778548a9ccb7b01f010d2321dd0b45165a7666",
-                "sha256:9b6181e5d6763e44b3f22e312f7b20c6c7cf1f4475dfb1266da7e151e877c580",
-                "sha256:9d7a210b61f3389659fd0d597d0f874fac0ab52da4569d878c40a41f09ff72db",
-                "sha256:a4230b02ead96e8a929daa7da1be48812cab0a45b5ea9dcdd8b7c15f5b688699",
-                "sha256:a64f6000880377821e97d74081f2e9560c7ec87371350bd03d996ee211a81342",
-                "sha256:b0de4b0a5076865399f3e7be7bdc72d6f2e28dbfcec0134629385c8b55a01174",
-                "sha256:b5e048fe372131e51092477565f9dd0bf0d3e52b13f5131d486491cb1cffdb68",
-                "sha256:b61b8126daf6ebde97da4268d3f55b8dae28f878002f978693e0584296119f7d",
-                "sha256:c41e7fc7bcf8e51c96d91afcba585a204b6b16113e8d5e9bf58ba98eb715b0b3",
-                "sha256:cd5dad2bf2a87b9f3e5f1c0f49a5874095e1e7488b5b4864dca1b8203d97e1b7",
-                "sha256:d271026b20d066b19d5a33846e496c4af9c2e34d5b321e60e15b8f37b9412b99",
-                "sha256:d2b4ae78f3c92f58927ad3d545fa10df3a9a782eed6f9984811779c515a8c25c",
-                "sha256:d2c5afce611fe3aa7e1320ef5184dd81634cb76fe6abf3ef40a25703fbb3c8b9",
-                "sha256:d6de896ccf410fbe77820652bcdeeee71e55e86186626365df547a0b262bc7c5",
-                "sha256:db925642c279847b4112181b46a623eb4b98e5854f19729bc02a65bc4177da54",
-                "sha256:ddb5b7a4f15f119c5464c036101b95beee755e2a6fd92b445f0b046a6fc4704d",
-                "sha256:e096aae05d1fe78c073c71ee18846e8161f12f0990573da257afffddc9f9c5bd",
-                "sha256:f1fdfea16b945f9a99e2a6be167e799d1d4fb8f3d27aa77f3d630ca82bc88bc6",
-                "sha256:f23f277bba1b13a1400a648fc01bc570c83abd048dfec2e992e7045c4ffd3259",
-                "sha256:f2e7ce37dbf7c75168d056a97b23715f1678fee212c60cbf1619605320afdf27",
-                "sha256:f533a3e3d5d2999e3d1b9b3d3d430197316697ae50fc07637e8c28118b624e20",
-                "sha256:fab4e00528c661c03deca168268d71e446dfcbae4fe7f43c99a76eb300423fb3",
-                "sha256:fae371d902b841ef595e0f81f86e02018e7441f171ecab81187381b8185e2caa",
-                "sha256:fc8ba98e4c0b45649fd2b64bce932dcd2f885a40164a7675b449785d0501d463",
-                "sha256:fce06cbb8c257ef6249c62cdfa6e985ed61742e96ac9ce8b0b6400872c1c170b",
-                "sha256:fe73645e0be4c5fe32cc8ccc90c7d7f7a75a0f82f7b99169f72d7d8e137d58f3"
+                "sha256:011aeac007fef655933720c5803ce2a321730243d9d1e44596a5c8effa9274fd",
+                "sha256:0299afb9c62381a0f29bdb7cd09f9a3d494d493f99767f4a4533fcaa0c4664be",
+                "sha256:03e13779e910e1b0286edddf176513e5de22bb8e570cdcfaa1d4c4914de9ca28",
+                "sha256:06254e70d7b290d265fa52510dc1318cf6b1e23eaafd33f6637caf577524078b",
+                "sha256:09ec04eedf8142c65884fabca5e66c758ef168dec9f363e121794ec62b58ae1e",
+                "sha256:0ac58b15864e33babb37b2cbf18446b00d8be8ffe25350fda1b85f2b0afff982",
+                "sha256:0cb878619fc0eafded5d3a8a443e3e001ca1ba2102e50615b43e8cdc48b9c87a",
+                "sha256:139374a63136f4c75acb77c250fadd23f580d65fcd6e34f3cffd66a7a9a73b55",
+                "sha256:178a8127b9293178aa499a8b8eca53c35516b30e0b53d12b07b1ac1848553943",
+                "sha256:1bc18ee59839289f395c75dde132b05a0f1a83a2bae0e9876d37e7d7dffd7b79",
+                "sha256:26fcf7181dff498ab177c42fec70fb2d17bdec737ed95a3b0fba3c79bd1e381b",
+                "sha256:2790588ce54a41f57d7412f6fcea5314175d4d3dca6bca3a0cfd14c842f3af1e",
+                "sha256:2b9380ffac05d289ae0aedfb49fb2e7170ecd30839e7ba37a159cd7ebc628f37",
+                "sha256:31c015bc786192da0b6a91667c13e39ca27fd53a9b23150765eab0639f1b7a40",
+                "sha256:34533650d6ccc89307d4a0def8caf59cc2722f595006cdc7f71d1d8540d650bf",
+                "sha256:374661237f62fcd31e3785d99f8c93540a2c98afc8adf5061b93e6f776a50488",
+                "sha256:37b4e4a5e18121ec16cfcad1636143a5cdb30d4e19a3a021112b6647f742f6c4",
+                "sha256:3a0c6dca436ee6b210e8f3f7d323c418bd052c20b5172c3fbaf671c666fcf29a",
+                "sha256:3c62fba49b9558c4a45c13276d03ac82544bdb6cbf5d459aff737382c60888c2",
+                "sha256:53450f8b0c5422a53328edc336ff451dd914d63ba53a962aa653c372a3cc61f0",
+                "sha256:55e160d27492a5f54cdb27cdceb1e54240aea714ceab6711ee6d0b7cd0b9fda8",
+                "sha256:57e58a2eeb43505848baa66c2b67c947835e303c7e09bf6bd67b4d50cbdb4f09",
+                "sha256:58a1625c885fa8ba3446b626304c7077e6fc766db2762500e76ce418821c5771",
+                "sha256:58c695f4fb8b94003c7c2de1e4970a78e09bdd010de530860885487456152867",
+                "sha256:5df6fbb6ac34f3787583697843dbb2dccbfd85d9b2ad8a037602a51d137c2c6c",
+                "sha256:5e4f57f5bc8817a9f1f6d49db4ea77eab4a09190a41779fac7982bfcaf0e810e",
+                "sha256:620f7fa749625417486c26f8374ad14366f0cb03a2ad3a63e2bc27ae8f68ec13",
+                "sha256:62863ee5df6ae3d665fb2eaa61ca64e31d62a96f25987d1b248b9ad64b191ed0",
+                "sha256:67ba759ae018c2cc125ef127253bb7e7584f29d2d738dc27fb6e86d9492094f3",
+                "sha256:808d44f6139fa88f0f855d486d542732ca99cc2f8e90566d094dc860b88228d9",
+                "sha256:822a2f8c55b05b67a84d6e05f934f4c4fab4fca4772f34f91680dd697c6eeed0",
+                "sha256:8804785b47db39ec362c2383b9058a0d1ce48fc40b2b5287700b79939e11883a",
+                "sha256:8a8e35c851db28707043924f19429b88947efe73f2164c82f0cefe4bc44f38ea",
+                "sha256:8ffa4e0968f8a0be44b8445b7ac0d5f48bb4dbf88bd18a5f609537905ca04c5f",
+                "sha256:96071e8c26ee234e348981c33a49bdae9fc824667fa2e18be65bebf0a05c229a",
+                "sha256:9984eb80933862347bb394d04f6e1f8969d51ea9241eed8980f17699e092bc83",
+                "sha256:9ee67485d54cbfd02db6a0ee71b7e94f959aa47574111eb5e92c554c2ca55a94",
+                "sha256:a17b9ad4818c2d742d4c30977cc89a2533fefb8d210bcf7f632fe601076e3e8b",
+                "sha256:a688fcb8904549c666090021a74cd63aa1e8bef6cd3797860167aa512172ba1b",
+                "sha256:a751c1c8ef84632f21d3df5d1d07cd11e0b1f74f14ca569ea74a627893b353f6",
+                "sha256:ab2cd9424988ac0141b7f52a5475e0a14a15f1e04d4c1c87351ad2f3698529e7",
+                "sha256:ab7681dc29cdbcefc1c201995f3af2742b17d1970fd27445b8818f8921bb7b0f",
+                "sha256:afdda451301e69a4b7e745c89b7fb34a7dba2b7943f1a72813e4f98f7038b065",
+                "sha256:c27c12990a1de26b8f8a8e3a6e4d39a261a641b5e147ab456c445355ad4855ae",
+                "sha256:c3ae9166956d67db5fffcd11c31dbea118af3af2bfcddd15458fd90de867f8bc",
+                "sha256:c6c979b7450ebd7bcf50017cc9f336b15ab2c8689b550baba21170ce2759915e",
+                "sha256:c89cd5b5dcbd158132f46f0fb29e75e4e0ccac1a9ef70f3d334162af3475ba21",
+                "sha256:cc40717d27d1c7bfe6da2989fb0afd8e24fd26b6e45da482050a32ac7e39bf87",
+                "sha256:d6feae52a09603f3c5b551a4268f27e9dba47465698fb773cbcc2e8e9f205ea5",
+                "sha256:da7452a592f90355d33c1937945b050106d27b2479e95260f5d77db2ec90f9e5",
+                "sha256:db6214062075f30fd25dcf9e582831019e0034a7e70c96fa928d27dd7cf8d8fe",
+                "sha256:dbe3548ac0a68ab88241f6ac03bc6b7c19c23160bd78ed4c94ae4d92196be230",
+                "sha256:e2966632427f549386ff0695bf59f0adf535031af771f4f76cb4b77c221ef5d6",
+                "sha256:e3a98b8cb41dfb7f8c5a6aa14b817f0b89c6048afe1242a97968c8a4c2c940be",
+                "sha256:e6a6567d90540fba350b039586b9da3ce335dd744a359f5fce4bb09fd7e9b4bb",
+                "sha256:ecf4c9b5ecbbb25fa0f8420544284387e0f98c2b96b19ebfb49afa8e8f153dea",
+                "sha256:f1672fcf432ab7f95333f36dcab4689253a5951bc0dfb807aa820abc4c8ea69f",
+                "sha256:f40701b71b417c54bb227a15ff3da49e38513decf7fcc48342b7564ad9edacc5",
+                "sha256:f7cb5600e73ff864eab1987ee51b493888efcb33054ed94472bdc26ab4db7ab0",
+                "sha256:ffaa6a3b30590d02e1d7c959049dc43eafb2b34c104e3fe78f188a9b39c33648"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.115.2"
+            "version": "==0.119.0"
         },
         "zope.interface": {
             "hashes": [
@@ -1203,11 +1203,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8",
-                "sha256:f2510e7fdcd6cfda4ec50014726d4857abf79acfc010084ce8c26091913f1b25"
+                "sha256:7d5895c9825e18079c5aeac0572bc2e4c83205c95d416e0b4fee8bc361d2d9ca",
+                "sha256:86b0bb7d7da0be1a7c4aedb7974e391b32d4ed89e33de6ed6902b4b15c97577e"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.0.0"
+            "version": "==3.0.1"
         },
         "attrs": {
             "hashes": [
@@ -1593,54 +1593,54 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:0922e3e34d95dbf3f0c84fc817a233e1cbd5874830c6fd821d525ba90e0ce077",
-                "sha256:efaa52843a8c64b99bcf5a97cf4ba57d410424828e3087b13c9b3954e8adb5ff"
+                "sha256:09665e60df7ee9e5ff3a54af173f6d45be718b1ee7dd962bcff3102b81fb0c14",
+                "sha256:78802035d5768a78139c84ad7dce0c6493e8f7dc4861727d36ed91d1520a54da"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==9.4.5"
+            "version": "==9.4.6"
         },
         "mkdocs-material-extensions": {
             "hashes": [
-                "sha256:27e2d1ed2d031426a6e10d5ea06989d67e90bb02acd588bc5673106b5ee5eedf",
-                "sha256:c767bd6d6305f6420a50f0b541b0c9966d52068839af97029be14443849fb8a1"
+                "sha256:0297cc48ba68a9fdd1ef3780a3b41b534b0d0df1d1181a44676fda5f464eeadc",
+                "sha256:f0446091503acb110a7cab9349cbc90eeac51b58d1caa92a704a81ca1e24ddbd"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3"
         },
         "mypy": {
             "hashes": [
-                "sha256:091f53ff88cb093dcc33c29eee522c087a438df65eb92acd371161c1f4380ff0",
-                "sha256:1a69db3018b87b3e6e9dd28970f983ea6c933800c9edf8c503c3135b3274d5ad",
-                "sha256:24f3de8b9e7021cd794ad9dfbf2e9fe3f069ff5e28cb57af6f873ffec1cb0425",
-                "sha256:31eba8a7a71f0071f55227a8057468b8d2eb5bf578c8502c7f01abaec8141b2f",
-                "sha256:3c8835a07b8442da900db47ccfda76c92c69c3a575872a5b764332c4bacb5a0a",
-                "sha256:3df87094028e52766b0a59a3e46481bb98b27986ed6ded6a6cc35ecc75bb9182",
-                "sha256:49499cf1e464f533fc45be54d20a6351a312f96ae7892d8e9f1708140e27ce41",
-                "sha256:4c192445899c69f07874dabda7e931b0cc811ea055bf82c1ababf358b9b2a72c",
-                "sha256:4f3d27537abde1be6d5f2c96c29a454da333a2a271ae7d5bc7110e6d4b7beb3f",
-                "sha256:7469545380dddce5719e3656b80bdfbb217cfe8dbb1438532d6abc754b828fed",
-                "sha256:7807a2a61e636af9ca247ba8494031fb060a0a744b9fee7de3a54bed8a753323",
-                "sha256:856bad61ebc7d21dbc019b719e98303dc6256cec6dcc9ebb0b214b81d6901bd8",
-                "sha256:89513ddfda06b5c8ebd64f026d20a61ef264e89125dc82633f3c34eeb50e7d60",
-                "sha256:8e0db37ac4ebb2fee7702767dfc1b773c7365731c22787cb99f507285014fcaf",
-                "sha256:971104bcb180e4fed0d7bd85504c9036346ab44b7416c75dd93b5c8c6bb7e28f",
-                "sha256:9e1589ca150a51d9d00bb839bfeca2f7a04f32cd62fad87a847bc0818e15d7dc",
-                "sha256:9f8464ed410ada641c29f5de3e6716cbdd4f460b31cf755b2af52f2d5ea79ead",
-                "sha256:ab98b8f6fdf669711f3abe83a745f67f50e3cbaea3998b90e8608d2b459fd566",
-                "sha256:b19006055dde8a5425baa5f3b57a19fa79df621606540493e5e893500148c72f",
-                "sha256:c69051274762cccd13498b568ed2430f8d22baa4b179911ad0c1577d336ed849",
-                "sha256:d2dad072e01764823d4b2f06bc7365bb1d4b6c2f38c4d42fade3c8d45b0b4b67",
-                "sha256:dccd850a2e3863891871c9e16c54c742dba5470f5120ffed8152956e9e0a5e13",
-                "sha256:e28d7b221898c401494f3b77db3bac78a03ad0a0fff29a950317d87885c655d2",
-                "sha256:e4b7a99275a61aa22256bab5839c35fe8a6887781862471df82afb4b445daae6",
-                "sha256:eb7ff4007865833c470a601498ba30462b7374342580e2346bf7884557e40531",
-                "sha256:f8598307150b5722854f035d2e70a1ad9cc3c72d392c34fffd8c66d888c90f17",
-                "sha256:fea451a3125bf0bfe716e5d7ad4b92033c471e4b5b3e154c67525539d14dc15a"
+                "sha256:19f905bcfd9e167159b3d63ecd8cb5e696151c3e59a1742e79bc3bcb540c42c7",
+                "sha256:21a1ad938fee7d2d96ca666c77b7c494c3c5bd88dff792220e1afbebb2925b5e",
+                "sha256:40b1844d2e8b232ed92e50a4bd11c48d2daa351f9deee6c194b83bf03e418b0c",
+                "sha256:41697773aa0bf53ff917aa077e2cde7aa50254f28750f9b88884acea38a16169",
+                "sha256:49ae115da099dcc0922a7a895c1eec82c1518109ea5c162ed50e3b3594c71208",
+                "sha256:4c46b51de523817a0045b150ed11b56f9fff55f12b9edd0f3ed35b15a2809de0",
+                "sha256:4cbe68ef919c28ea561165206a2dcb68591c50f3bcf777932323bc208d949cf1",
+                "sha256:4d01c00d09a0be62a4ca3f933e315455bde83f37f892ba4b08ce92f3cf44bcc1",
+                "sha256:59a0d7d24dfb26729e0a068639a6ce3500e31d6655df8557156c51c1cb874ce7",
+                "sha256:68351911e85145f582b5aa6cd9ad666c8958bcae897a1bfda8f4940472463c45",
+                "sha256:7274b0c57737bd3476d2229c6389b2ec9eefeb090bbaf77777e9d6b1b5a9d143",
+                "sha256:81af8adaa5e3099469e7623436881eff6b3b06db5ef75e6f5b6d4871263547e5",
+                "sha256:82e469518d3e9a321912955cc702d418773a2fd1e91c651280a1bda10622f02f",
+                "sha256:8b27958f8c76bed8edaa63da0739d76e4e9ad4ed325c814f9b3851425582a3cd",
+                "sha256:8c223fa57cb154c7eab5156856c231c3f5eace1e0bed9b32a24696b7ba3c3245",
+                "sha256:8f57e6b6927a49550da3d122f0cb983d400f843a8a82e65b3b380d3d7259468f",
+                "sha256:925cd6a3b7b55dfba252b7c4561892311c5358c6b5a601847015a1ad4eb7d332",
+                "sha256:a43ef1c8ddfdb9575691720b6352761f3f53d85f1b57d7745701041053deff30",
+                "sha256:a8032e00ce71c3ceb93eeba63963b864bf635a18f6c0c12da6c13c450eedb183",
+                "sha256:b96ae2c1279d1065413965c607712006205a9ac541895004a1e0d4f281f2ff9f",
+                "sha256:bb8ccb4724f7d8601938571bf3f24da0da791fe2db7be3d9e79849cb64e0ae85",
+                "sha256:bbaf4662e498c8c2e352da5f5bca5ab29d378895fa2d980630656178bd607c46",
+                "sha256:cfd13d47b29ed3bbaafaff7d8b21e90d827631afda134836962011acb5904b71",
+                "sha256:d4473c22cc296425bbbce7e9429588e76e05bc7342da359d6520b6427bf76660",
+                "sha256:d8fbb68711905f8912e5af474ca8b78d077447d8f3918997fecbf26943ff3cbb",
+                "sha256:e5012e5cc2ac628177eaac0e83d622b2dd499e28253d4107a08ecc59ede3fc2c",
+                "sha256:eb4f18589d196a4cbe5290b435d135dee96567e07c2b2d43b5c4621b6501531a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.6.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1698,12 +1698,12 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:6bbd5129a64cad4c0dfaeeb12cd8f7ea7e15b77028d985341478c8af3c759522",
-                "sha256:96d529a951f8b677f730a7212442027e8ba53f9b04d217c4c67dc56c393ad945"
+                "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32",
+                "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.4.0"
+            "version": "==3.5.0"
         },
         "pygments": {
             "hashes": [
@@ -1976,11 +1976,12 @@
         },
         "types-pillow": {
             "hashes": [
-                "sha256:54a49f3c6a3f5e95ebeee396d7773dde22ce2515d594f9c0596c0a983558f0d4",
-                "sha256:ae0c877d363da349bbb82c5463c9e78037290cc07d3714cb0ceaf5d2f7f5c825"
+                "sha256:0f5e7cf010ed226800cb5821e87781e5d0e81257d948a9459baa74a8c8b7d822",
+                "sha256:f97f596b6a39ddfd26da3eb67421062193e10732d2310f33898d36f9694331b5"
             ],
             "index": "pypi",
-            "version": "==10.0.0.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==10.1.0.0"
         },
         "types-python-dateutil": {
             "hashes": [
@@ -1992,12 +1993,12 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:39894cbca3fb3d032ed8bdd02275b4273471aa5668564617cc1734b0a65ffdf8",
-                "sha256:e1b325c687b3494a2f528ab06e411d7092cc546cc9245c000bacc2fca5ae96d4"
+                "sha256:b32b9a86beffa876c0c3ac99a4cd3b8b51e973fb8e3bd4e0a6bb32c7efad80fc",
+                "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.31.0.8"
+            "version": "==2.31.0.10"
         },
         "typing-extensions": {
             "hashes": [
@@ -2009,11 +2010,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
+                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.7"
         },
         "virtualenv": {
             "hashes": [
@@ -2311,20 +2312,20 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:0922e3e34d95dbf3f0c84fc817a233e1cbd5874830c6fd821d525ba90e0ce077",
-                "sha256:efaa52843a8c64b99bcf5a97cf4ba57d410424828e3087b13c9b3954e8adb5ff"
+                "sha256:09665e60df7ee9e5ff3a54af173f6d45be718b1ee7dd962bcff3102b81fb0c14",
+                "sha256:78802035d5768a78139c84ad7dce0c6493e8f7dc4861727d36ed91d1520a54da"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==9.4.5"
+            "version": "==9.4.6"
         },
         "mkdocs-material-extensions": {
             "hashes": [
-                "sha256:27e2d1ed2d031426a6e10d5ea06989d67e90bb02acd588bc5673106b5ee5eedf",
-                "sha256:c767bd6d6305f6420a50f0b541b0c9966d52068839af97029be14443849fb8a1"
+                "sha256:0297cc48ba68a9fdd1ef3780a3b41b534b0d0df1d1181a44676fda5f464eeadc",
+                "sha256:f0446091503acb110a7cab9349cbc90eeac51b58d1caa92a704a81ca1e24ddbd"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3"
         },
         "packaging": {
             "hashes": [
@@ -2566,11 +2567,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
+                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.7"
         },
         "watchdog": {
             "hashes": [


### PR DESCRIPTION
This is an automated update of the `Pipfile.lock` file.

```
astroid==3.0.0;              |  astroid==3.0.1;
mkdocs-material-extensions== |  mkdocs-material-extensions==
mkdocs-material==9.4.5;      |  mkdocs-material==9.4.6;
mypy==1.6.0;                 |  mypy==1.6.1;
numpy==1.26.0;               |  numpy==1.26.1;
pillow==10.0.1;              |  pillow==10.1.0;
pre-commit==3.4.0;           |  pre-commit==3.5.0;
pyinstaller-hooks-contrib==2 |  pyinstaller-hooks-contrib==2
pyinstaller==6.0.0;          |  pyinstaller==6.1.0;
types-pillow==10.0.0.3                             |  types-pillow==10.1.0.0;
types-requests==2.31.0.8;    |  types-requests==2.31.0.10;
urllib3==2.0.6;              |  urllib3==2.0.7;
zeroconf==0.115.2;           |  zeroconf==0.119.0;
```