### PR TITLE
Update renovate pre-commit to use lts version of node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,4 @@ repos:
     rev: "38.115.1"
     hooks:
       - id: renovate-config-validator
+        language_version: lts # Use the LTS version of Node.js


### PR DESCRIPTION
Works around renovatebot/pre-commit-hooks#2460 by overriding the version of nodejs that is installed. Inspired by https://github.com/renovatebot/pre-commit-hooks/issues/2460#issuecomment-2419904203.

Root cause seems to be that pre-commit defaults to installing the latest version of node if (1) it's not already present or (2) it's running on Windows: https://github.com/pre-commit/pre-commit/blob/611195a088a29821961c5ddae2f4312f748f4a85/pre_commit/languages/node.py#L27-L36
So, when node 23 was released, the renovate hook broke.

Based on https://github.com/pre-commit/pre-commit/issues/3340 and https://github.com/ekalinin/nodeenv/pull/281, I'm just requesting LTS instead of locking to a specific version.