### PR TITLE
[workflow] Update dependencies in lockfiles

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.4.6"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/07/508f9ebba367fc3370162e53a3cfd12f5652ad79f0e0bfdf9f9847c6f159/aiohappyeyeballs-2.4.6.tar.gz", hash = "sha256:9b05052f9042985d32ecbe4b59a77ae19c006a78f1344d7fdad69d28ded3d0b0", size = 21726 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/0c/458958007041f4b4de2d307e6b75d9e7554dad0baf26fe7a48b741aac126/aiohappyeyeballs-2.5.0.tar.gz", hash = "sha256:18fde6204a76deeabc97c48bdd01d5801cfda5d6b9c8bbeb1aaaee9d648ca191", size = 22494 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/4c/03fb05f56551828ec67ceb3665e5dc51638042d204983a03b0a1541475b6/aiohappyeyeballs-2.4.6-py3-none-any.whl", hash = "sha256:147ec992cf873d74f5062644332c539fcd42956dc69453fe5204195e560517e1", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/1b/9a/e4886864ce06e1579bd428208127fbdc0d62049c751e4e9e3b509c0059dc/aiohappyeyeballs-2.5.0-py3-none-any.whl", hash = "sha256:0850b580748c7071db98bffff6d4c94028d0d3035acc20fd721a0ce7e8cac35d", size = 15128 },
 ]
 
 [[package]]
@@ -514,14 +514,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -1110,16 +1110,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "5.29.3"
+version = "6.30.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/d1/e0a911544ca9993e0f17ce6d3cc0932752356c1b0a834397f28e63479344/protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620", size = 424945 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/6a/2629bb3529e5bdfbd6c4608ff5c7d942cd4beae85793f84ba543aab2548a/protobuf-6.30.0.tar.gz", hash = "sha256:852b675d276a7d028f660da075af1841c768618f76b90af771a8e2c29e6f5965", size = 429239 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/7a/1e38f3cafa022f477ca0f57a1f49962f21ad25850c3ca0acd3b9d0091518/protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888", size = 422708 },
-    { url = "https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a", size = 434508 },
-    { url = "https://files.pythonhosted.org/packages/dd/04/3eaedc2ba17a088961d0e3bd396eac764450f431621b58a04ce898acd126/protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e", size = 417825 },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7c467744d23c3979ce250397e26d8ad8eeb2bea7b18ca12ad58313c1b8d5/protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84", size = 319573 },
-    { url = "https://files.pythonhosted.org/packages/a8/45/2ebbde52ad2be18d3675b6bee50e68cd73c9e0654de77d595540b5129df8/protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f", size = 319672 },
-    { url = "https://files.pythonhosted.org/packages/fd/b2/ab07b09e0f6d143dfb839693aa05765257bceaa13d03bf1a696b78323e7a/protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f", size = 172550 },
+    { url = "https://files.pythonhosted.org/packages/aa/76/8b1cbf762d98b09fcb29bbc6eca97dc6e1cd865b97a49c443aa23f1a9f82/protobuf-6.30.0-cp310-abi3-win32.whl", hash = "sha256:7337d76d8efe65ee09ee566b47b5914c517190196f414e5418fa236dfd1aed3e", size = 419141 },
+    { url = "https://files.pythonhosted.org/packages/57/50/2ea2fb4533321438f5106723c70c303529ba184540e619ebe75e790d402e/protobuf-6.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:9b33d51cc95a7ec4f407004c8b744330b6911a37a782e2629c67e1e8ac41318f", size = 430995 },
+    { url = "https://files.pythonhosted.org/packages/a1/7d/a7dfa7aa3deda114920b1ed57c0026e85a976e74658db2784a0443510252/protobuf-6.30.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:52d4bb6fe76005860e1d0b8bfa126f5c97c19cc82704961f60718f50be16942d", size = 417570 },
+    { url = "https://files.pythonhosted.org/packages/11/87/a9c7b020c4072dc34e3a2a3cde69366ffc623afff0e7f10f4e5275aaec01/protobuf-6.30.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:7940ab4dfd60d514b2e1d3161549ea7aed5be37d53bafde16001ac470a3e202b", size = 317310 },
+    { url = "https://files.pythonhosted.org/packages/95/66/424db2262723781dc94208ff9ce201df2f44f18a46fbff3c067812c6b5b9/protobuf-6.30.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:d79bf6a202a536b192b7e8d295d7eece0c86fbd9b583d147faf8cfeff46bf598", size = 316203 },
+    { url = "https://files.pythonhosted.org/packages/51/6f/21c2b7de96c3051f847a4a88a12fdf015ed6b7d50fc131fb101a739bd7a5/protobuf-6.30.0-py3-none-any.whl", hash = "sha256:e5ef216ea061b262b8994cb6b7d6637a4fb27b3fb4d8e216a6040c0b93bd10d7", size = 167054 },
 ]
 
 [[package]]
@@ -1219,15 +1219,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.395"
+version = "1.1.396"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/47/a2e1dfd70f9f0db34f70d5b108c82be57bf24185af69c95acff57f9239fa/pyright-1.1.395.tar.gz", hash = "sha256:53703169068c160bfb41e1b44ba3e2512492869c26cfad927e1268cb3fbb1b1c", size = 3813566 }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/73/f20cb1dea1bdc1774e7f860fb69dc0718c7d8dea854a345faec845eb086a/pyright-1.1.396.tar.gz", hash = "sha256:142901f5908f5a0895be3d3befcc18bedcdb8cc1798deecaec86ef7233a29b03", size = 3814400 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/a1/531897f8caa6c6cc99862cd1c908ddd8a366a51d968e83ab4523ded98b30/pyright-1.1.395-py3-none-any.whl", hash = "sha256:f9bc726870e740c6c77c94657734d90563a3e9765bb523b39f5860198ed75eef", size = 5688787 },
+    { url = "https://files.pythonhosted.org/packages/80/be/ecb7cfb42d242b7ee764b52e6ff4782beeec00e3b943a3ec832b281f9da6/pyright-1.1.396-py3-none-any.whl", hash = "sha256:c635e473095b9138c471abccca22b9fedbe63858e0b40d4fc4b67da041891844", size = 5689355 },
 ]
 
 [[package]]
@@ -1643,50 +1643,56 @@ wheels = [
 
 [[package]]
 name = "zeroconf"
-version = "0.145.1"
+version = "0.146.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ifaddr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/96ab70984550e305fc85094d15b7b5317cbefdbcd5078659ffe5639d83ec/zeroconf-0.145.1.tar.gz", hash = "sha256:3acb6146595597cfe6e314f8a4d530e659fcd9f9028cc9603a00518c98e57dd2", size = 161640 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/6b/5fa7a4c677376b549655d67f6902c80bde4b534405cdf2b5f0c50cc7bd8a/zeroconf-0.146.1.tar.gz", hash = "sha256:c53c07d6df3698bd19dcc832a897181872ec47e98e7cd70cff6c1bb0aff0bbfd", size = 161874 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/77/dcbda8d874918558678875aca68e30741748ea1293179cb61696556962f7/zeroconf-0.145.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0a122323b759d82c8df10f94de8f0670a2101ff233e57f9ee7200148dfffcebc", size = 1932374 },
-    { url = "https://files.pythonhosted.org/packages/35/40/0905f23b4bf8bdfa9cc555e0316b3c8c8ae45772ee414ec88be58da1ceef/zeroconf-0.145.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5f7c8a91c54c86f70bf53ab7d79720865e0ccd1a0d8e11d8350de09af3ab9978", size = 1778854 },
-    { url = "https://files.pythonhosted.org/packages/67/a9/7e9211c08ba425056c564504505891f84245fd325bc4cbabe87dea0dea5c/zeroconf-0.145.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f483f10e07f4797bd7f286de5d8b5fcd0cf379c6f0f2377eaf54de6e9a42564", size = 11497027 },
-    { url = "https://files.pythonhosted.org/packages/a6/56/b049f63c60b95bcb211de8e3a39b43596f67b4448bd3b129dc0c5fc5b0ec/zeroconf-0.145.1-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:d3066fa4d39834c2cd640ba16f955d4a81185b1828d3ceaf0266b7a974f80bc0", size = 11017647 },
-    { url = "https://files.pythonhosted.org/packages/91/3d/43a37fe9d8362a9773422fcd500341ec3d4c684c4b095e0a9d4227133bb6/zeroconf-0.145.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b571b947c5bfde639402b598a5df7dbad0193ec99802b5eef9f38984d0ccdee", size = 11553669 },
-    { url = "https://files.pythonhosted.org/packages/a2/fd/7c29a9407fad7848991fb9c9fbd1941ec493fc8531bb9153c7523ab75a1b/zeroconf-0.145.1-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ef3faec1164d3b1a0c2134b0ad0b788141712172d5aa08fad61699c48a91a62d", size = 10498026 },
-    { url = "https://files.pythonhosted.org/packages/a9/92/7c5b05cdfa1c85d6eb6f949e086750c48c3b33f1f5aa161f32620f589c76/zeroconf-0.145.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58ac90d25c9dc07659782cef4330592bd25d9033d3313bcbaf497ed2dfcfc761", size = 11459401 },
-    { url = "https://files.pythonhosted.org/packages/1a/b5/71542f54dd5fa996d0e40eaa1a4e9f199d5cc5e4ca18e2ea9f4bfd51b223/zeroconf-0.145.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c183ae3801a95a74d78aa0cceddefcba991d407a2b07d94d082528a55a246890", size = 11129078 },
-    { url = "https://files.pythonhosted.org/packages/37/5f/2a7d6e01898d197310608d224b102d20124c8dc45c74fafae2219f9c0b56/zeroconf-0.145.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d536eb98a9e568d798aa348264b7f86b14081841f9c041008216e65a032b6eb7", size = 11351841 },
-    { url = "https://files.pythonhosted.org/packages/2d/ce/8d4e8f7d03b51bdcc7927d58a9213fb14e1b4c11de6708c688ac1b1c74b0/zeroconf-0.145.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18c7d261b6f4ce5d9dc38744b7c31b3d1ed38e781e0a4be84980f3d990c300ea", size = 11863097 },
-    { url = "https://files.pythonhosted.org/packages/88/b7/ad3e4965914f2d27b9233f4bd7b859409fc917f78b10028b1bc32805d3ff/zeroconf-0.145.1-cp311-cp311-win32.whl", hash = "sha256:02dda253df44749a59826cf89634d3aebb1e4eafa0aad7f8b420d992a08707f4", size = 1428083 },
-    { url = "https://files.pythonhosted.org/packages/c6/a9/f95671d9e3aafd2c899e5592dc47b721fc5cfc60cce2ed28d6c7c1dd69fd/zeroconf-0.145.1-cp311-cp311-win_amd64.whl", hash = "sha256:dd536a6f06a944fd0d2a1c91fe4e29b933a4730b67435c839b5c29ea0df46184", size = 1663804 },
-    { url = "https://files.pythonhosted.org/packages/12/d2/425fffc3fa37b8aef36483bce8a31f89d9f4b97e116d9a1c62c77138f887/zeroconf-0.145.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a7ad4f8cb358d7d27e6ea2f18c5588bb024104389502a818d783640acd1c518b", size = 1950686 },
-    { url = "https://files.pythonhosted.org/packages/69/68/b79b6eb74f4faa752ce5e0ec9e31fa6f26d0d9087893352efbd7b6950225/zeroconf-0.145.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33a173127b8724868746e7b6739460549706652fe9ec9713a41bce958e5e09fa", size = 1796925 },
-    { url = "https://files.pythonhosted.org/packages/c1/ff/b3f0fc46ad68a5973555f0eda16c41de04400258de9241e5b55ec07761d6/zeroconf-0.145.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:644658b23a5304f91bed196f185d330641d400eb7bb8875fc0c00b2419b495d1", size = 11165475 },
-    { url = "https://files.pythonhosted.org/packages/a8/0e/e5bc61fb191a891c11b8941bdccb92140129e61be01b4bc7df27626721d1/zeroconf-0.145.1-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:7e3190d2f7eae01c0131742356b9eec2752378ff212c94681629cf945c5a1eab", size = 10691655 },
-    { url = "https://files.pythonhosted.org/packages/26/10/4b4d1743d06b03f95055377e887a46a8ea5e2637094e1068224df1658f78/zeroconf-0.145.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f46c5a62e85c203b652228eec97bc8ec944b482c2a6274077c6bc8df402fe97d", size = 11337162 },
-    { url = "https://files.pythonhosted.org/packages/3e/d5/d5997606e1010be57cdf8073f5f8900ba121ccf2c6e0d007714e6bd45d21/zeroconf-0.145.1-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e7420eb60451a1c07fbcfe22a49e57f0a1df36a6a755966fb9b041a873b8d9", size = 10376142 },
-    { url = "https://files.pythonhosted.org/packages/ad/a2/3607f80068e89500fafc1f96b717ed6e123cf8231810f44dea191d68bd9a/zeroconf-0.145.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d0f93a945baf84005eba4c6caf17ae6a9b176e611131080cc1c7a70bc07502bd", size = 11200081 },
-    { url = "https://files.pythonhosted.org/packages/24/68/aac1fe73d7f370ab5766c2f8a14f5c35089946b46bc9450849cd90e87674/zeroconf-0.145.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:af398a7c667b404a66effeedc2c7fe47858fe48b5ced3f2b7dbb1f783b3a666b", size = 11165844 },
-    { url = "https://files.pythonhosted.org/packages/c1/ce/caff7d9b136b862deae3ba0358892d51c0d0ceabca7a92194d16a937d9e9/zeroconf-0.145.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d716f59cc6cd1da397b60e59abd0c7214d0756f3217829f6c39ae8d565de6874", size = 11144882 },
-    { url = "https://files.pythonhosted.org/packages/8a/8d/4486b92909bb1fc72430ad0dd8a51a161f4ef020c60bc01e2990727bc855/zeroconf-0.145.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4121126401c768b23dfde4edc7d0f50533efb4f12138e00403d150c278dd366d", size = 11631668 },
-    { url = "https://files.pythonhosted.org/packages/c7/82/7eb0669759fdf10a3abf8370defcb8d0d85ec3db7ace40f08fc628efc4f0/zeroconf-0.145.1-cp312-cp312-win32.whl", hash = "sha256:38620c18817026a03afb92ef65642d51a2f4d4a9761f67a6520914709e5cea74", size = 1431638 },
-    { url = "https://files.pythonhosted.org/packages/6f/2a/2e83d29902a33887b8b8434ca13eb6ba6bca7f66ac29704647c9c4f43bbf/zeroconf-0.145.1-cp312-cp312-win_amd64.whl", hash = "sha256:31ad6428646899206097c05b83dc1f15c04b7292c0c7080459c637e1c8c16329", size = 1661171 },
-    { url = "https://files.pythonhosted.org/packages/01/25/deb62b6085e4ad7045c62aec9a47c979b4f552cc485f50993e20f68feef5/zeroconf-0.145.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9bdaab78c0614cae35688233005ad0110830409fc0d8b109ac6d137f1c9089e0", size = 1927433 },
-    { url = "https://files.pythonhosted.org/packages/d4/84/359540dee8b0824bf07ea7922c42aa95134828be302a977936aa8c182791/zeroconf-0.145.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d7ec1c18754cc259bc7427ab0a2cbd9618df1b6191c4c1d12a3711be91f3056f", size = 1775810 },
-    { url = "https://files.pythonhosted.org/packages/fe/fe/328c30daedd40f887a05866fd3921a588963b6114b98b014612a179b263f/zeroconf-0.145.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9fc911eb64f39ddd450765a5d9c14e40684e9b7e4fbcd889029c7e55df4ef42", size = 11072222 },
-    { url = "https://files.pythonhosted.org/packages/a8/2a/a85d4cc38e53e2a4a5951ee812c1fca745d1357ec32dfc44d955fb99c9e3/zeroconf-0.145.1-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:5059206ced168de97a1e98cf975afe6b722996d371c718f1b28254ea51de0608", size = 10595955 },
-    { url = "https://files.pythonhosted.org/packages/30/57/c1e414c22f3e9a76edf82213804d3169536b94c59ad6880f453ae0bf61f5/zeroconf-0.145.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91797cbe49603861638c8476b15316483b307cc7567a4029d31463cd5c368089", size = 11270854 },
-    { url = "https://files.pythonhosted.org/packages/cc/43/a76b9c3f764e4cf6628983d6dcd6173c987cb64c3a72b60d015e683c720b/zeroconf-0.145.1-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a28f80b0d7b3c448a8c513a05a8333db46653f326be1ff28f904f5a3f629f782", size = 10320728 },
-    { url = "https://files.pythonhosted.org/packages/83/16/e31b8df2aa542e48b3d57e4143467f7f608b6459f331b67870598d46d878/zeroconf-0.145.1-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:326652faaafddb50137c4ed4a07c1f376c9b6f05f42c70a94a73be25d978a029", size = 11261628 },
-    { url = "https://files.pythonhosted.org/packages/6b/91/653b3d232a43b8d172e0202653cf7d735a02e6cc1a1245e0cae03d67fd0d/zeroconf-0.145.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:144a6e014bcff9833a6b520baba11cc58e847f304617bdf86019185841fa084d", size = 11098877 },
-    { url = "https://files.pythonhosted.org/packages/90/1e/1a2fd4d2e68f16a5e33132131b4abe05b80b5881997f6309f35eb76518c2/zeroconf-0.145.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:dcabf69870e697c4350836e9b9103cd794ac9d4e90b64eb62172d51bbc29273e", size = 11075217 },
-    { url = "https://files.pythonhosted.org/packages/7e/bb/5824e4676859d6d4be07b8655ef277c643309fb316ae20f9358f5bb7a07c/zeroconf-0.145.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:db2d028a1c60c246ea9395884a8688e28aed796d2b47bd361baeb1868d59bc2e", size = 11042443 },
-    { url = "https://files.pythonhosted.org/packages/8c/b5/54ad2af46444b9ce1195625d013081376f0a59de9d48a6a8ef19713f07a5/zeroconf-0.145.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ba4a052296e76a38d129238743e4b1851bfb95b7e978663001c1409ae56ed9ca", size = 11554295 },
-    { url = "https://files.pythonhosted.org/packages/40/29/f1e69b0d84db0ca138ca2f71a8b2920f493dc30aa812cdbebad765d4924d/zeroconf-0.145.1-cp313-cp313-win32.whl", hash = "sha256:b9d09e6d060ad4683ebb1f9b76fee44c3c43440c63639f41c7349a2e5cde3935", size = 1427575 },
-    { url = "https://files.pythonhosted.org/packages/80/5a/ca063fcc5139445105e1669412d18508ad1a0e463e37307bbcdce626d5d6/zeroconf-0.145.1-cp313-cp313-win_amd64.whl", hash = "sha256:5ee6f403e9222e3f817aabafeec7f6962624ddfb9728acbff57db74e406729e5", size = 1655835 },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/eeb754f8085e452ef697c5d37ae081107d8e64b96e9dfd25ceee5ba7c3f0/zeroconf-0.146.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b4d40d0025af1e014929eacf9b29be10397ea7ddb52f02a6c1ed4421ffa2d", size = 1841228 },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/076b8fbe09640353b1648947f933f18c541a7926f232c2f31f853e068dc7/zeroconf-0.146.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a27eb1a34e5cae832552d2287a2aba50518b6efa1fd07ba3f3aa661bb9294d2a", size = 1698739 },
+    { url = "https://files.pythonhosted.org/packages/86/79/44e2624f49520b73a4baf48a7e14e00f5cec6b0695474a2b9b43112a2fc7/zeroconf-0.146.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86d2ea3e4469f7c0221e15eddbfdb02a0e03501eefaa70329488a4a9c469b1f8", size = 2246020 },
+    { url = "https://files.pythonhosted.org/packages/f5/0b/22d0b7fa0648132d8773961c7387990412e9300e24196b31995dfb61a3e8/zeroconf-0.146.1-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:c0022e51660bb2f501c78fe1e5f668e87a79ae8dc28b1704eadcbb4ced288392", size = 2412294 },
+    { url = "https://files.pythonhosted.org/packages/4f/93/c028755987d09427309242e96fdd7a71d9826baa27922fdd28c388a3a605/zeroconf-0.146.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84d8827e33d6b10c64304fe74488a4c20d64d0357d2b5134740a477f716430b0", size = 2357771 },
+    { url = "https://files.pythonhosted.org/packages/83/b1/89cd072592ae8a8bbe5ff743e703bdc363305a02d205f8b29b4d43241701/zeroconf-0.146.1-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d00f3a6307bea1498baf15c52a1785cb757edbefd8aa961d26f83071d9b8c15b", size = 2144628 },
+    { url = "https://files.pythonhosted.org/packages/74/5a/2be1d95e300ff1a964a5de3551e3847126031219ba3fe799c93971ff113d/zeroconf-0.146.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00d39fd411ff2f0c0969ea7edcdb934a18244815de8e27ae0b27b5141a4f51f6", size = 2388088 },
+    { url = "https://files.pythonhosted.org/packages/1e/84/1830280ebad920ebf8400835a508795f040c00cae905d7f99a68bc74044b/zeroconf-0.146.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:33bc4df70076ab18a76c1fe2a30b64c6634875f50284245f1f029c276c72ca45", size = 2180593 },
+    { url = "https://files.pythonhosted.org/packages/38/34/e2b236f220d5858b5a3840645fa7c7280cca1857b1e4f5fb4856b6ab9701/zeroconf-0.146.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ee6cb4a2fe5eeec3b8f54c027e9aa0e5d04bec8e31305993551d1bb9e5f32043", size = 2565446 },
+    { url = "https://files.pythonhosted.org/packages/42/c9/eba886d66694827371e20b9cd23e2a61430373bab2e5ba12b288c257ee75/zeroconf-0.146.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c1bed42e701723e39a713e1e4d691bda3f60aa64f61be0d1480c5046f48da342", size = 2533331 },
+    { url = "https://files.pythonhosted.org/packages/2c/2f/d498c4ef030815148aad242c3d38197bedbadbcdc447430cf1c971464cee/zeroconf-0.146.1-cp311-cp311-win32.whl", hash = "sha256:e18702634444f8b66260e91555a2c858af75ecdb834cfbbdc33e60fc7fc448d5", size = 1428073 },
+    { url = "https://files.pythonhosted.org/packages/b7/b4/93e1d62a8e6fd64b5ccbc4f4586c95be89fd0e22167aed91ebb89d8750e4/zeroconf-0.146.1-cp311-cp311-win_amd64.whl", hash = "sha256:461fd00cc5e2ad54a64cbf9dcde231ce6d94c815faaa3b177d238a9c4c07031a", size = 1663817 },
+    { url = "https://files.pythonhosted.org/packages/3d/b5/73c888d9539d740da3b6c67c991b733a05e16580d6164b129bbbe34f3a0d/zeroconf-0.146.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d424ffaeecb6269593e3f12a4a9485e84cb4020ca6653b85a4601c44db828f06", size = 1862912 },
+    { url = "https://files.pythonhosted.org/packages/79/ba/eada7cfa6b1d5892749a4b76c764e1e20086f3abdcec0ba0f4d97856220e/zeroconf-0.146.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f37b5bc2e7dbd0eb808ef3128be3330ac95563be7840828a92bed7b3802c8e43", size = 1716715 },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/8c11ee0d1531b64a80997c58bbdee682d73e45f3e22b2d3399d8d34d72a7/zeroconf-0.146.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51ae9d425e264169232ab8b6b307c3907028a7dd85d8c92bb6e2fbe769fcf1c8", size = 2154700 },
+    { url = "https://files.pythonhosted.org/packages/53/6f/53147b863ad52e35f0c052f6e7f5bbb8ef7d6741775790913b2ee8082dbe/zeroconf-0.146.1-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:afff2344d46237c42172f67462ac274ffedc8eddf2f636cf23c9bc032cbb92a9", size = 2329443 },
+    { url = "https://files.pythonhosted.org/packages/75/98/2a6b1f4337c6b3fc1c185bd1d4f1f3dc3dfea9560613025adbda375f35f5/zeroconf-0.146.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e70779bd4148093d38fa3de3154076cbb896c45aa6215fbd2bb7c0fc4485a26", size = 2270278 },
+    { url = "https://files.pythonhosted.org/packages/45/bd/50902f98e41696bb9276c20b0e03751421ec79043785d53fffc7a1b30392/zeroconf-0.146.1-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8e333b09aaad626d761eaae116fa19ba889eba68165a449f558ff41644a63c1d", size = 2109846 },
+    { url = "https://files.pythonhosted.org/packages/d8/3a/4293aa7ccf957d9df485652b72509ae6c6185e65750851c699d8c3cb9ca3/zeroconf-0.146.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ace4c325d0d5962e8c93aff063cd1f932a2a4cabe6894b2cd44e383b607d9022", size = 2296623 },
+    { url = "https://files.pythonhosted.org/packages/fa/07/99e4a827d47f92cd7b7ed644789ed7509035c4af2b6cbd7c2f203908cb64/zeroconf-0.146.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:11ac58067a0f644a269ba03c25694381b92f0d595a22eb11937425d79c868613", size = 2158012 },
+    { url = "https://files.pythonhosted.org/packages/29/7b/29551afe08a0cc4dd8982d1916119f9079ad4f0718a7abd8ab7b009de674/zeroconf-0.146.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8bd650ac4cca3cdd20888f3529710a683ea9e2d5b88700d279946e9e0f8ae16e", size = 2502892 },
+    { url = "https://files.pythonhosted.org/packages/29/fa/337c9191b327e003609ce2a196de1035dcf294c89203bcbd94cd1d6786bd/zeroconf-0.146.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0909240c7867a69f88e24ee9db5ae1fda85133252c9d15bf11d2bcc56eabaa1b", size = 2466407 },
+    { url = "https://files.pythonhosted.org/packages/be/af/da04e47b3e303abd402bdc3a2e4e4b966a28244592d1860504024e1d31b8/zeroconf-0.146.1-cp312-cp312-win32.whl", hash = "sha256:08bc77681ab954250d294b5192891f2b21720be8bd9d0f506cdd4b54096a5137", size = 1431615 },
+    { url = "https://files.pythonhosted.org/packages/ef/d1/53670af03553c3cfcf7462b6c045e8f6670abdd7a2f2993eea2fed39a4fa/zeroconf-0.146.1-cp312-cp312-win_amd64.whl", hash = "sha256:6e43d73b1a9df91813d10f5ac1a3018092e472dfef7d387c605bf59137bb918a", size = 1661169 },
+    { url = "https://files.pythonhosted.org/packages/18/83/9888f57636e6b0ec9a51da08887055cfcda31c49b0b45b2e946d56a583f3/zeroconf-0.146.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91e40db3de595a0329822946bddfdb2903cd987eb6e5c30d94967634c38adb9a", size = 1840888 },
+    { url = "https://files.pythonhosted.org/packages/f6/90/f699647315d4761fc3de16d095a9452cb8e0253301cc6718fc0a3fa58cae/zeroconf-0.146.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:904653d351594e5eab6b520d12f25f9df98407bd1fdc4b79664b6f59da179184", size = 1697124 },
+    { url = "https://files.pythonhosted.org/packages/4e/d4/687320faafd87e40cc37fd072bd95fca86eceeac8bf39dff7a78552d8d7b/zeroconf-0.146.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a61da51c2bf50eddd1fd1642c9d84a7abdb42e2856483d2405f0938ad0ec7992", size = 2143633 },
+    { url = "https://files.pythonhosted.org/packages/4a/cc/52afa34bd7ce76fb5762bc25758f96427c18b5585aeac751693875f45ea2/zeroconf-0.146.1-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:ad4142368955cf706701dedb6a0f4b0019c7dce04bd3306ac3a502c0d8abb081", size = 2315078 },
+    { url = "https://files.pythonhosted.org/packages/db/2f/523cdbc546bf37485346c49762b39a5872b31425258271fd59c8a5860685/zeroconf-0.146.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6332377a66afb37a8c10bba350daf87a4ee2d9d3709f001dba3e40b4dc9e5240", size = 2260655 },
+    { url = "https://files.pythonhosted.org/packages/ed/b6/7933c47513244f64d11e5a627b6e4cfdf9096fd553ced3183922b1f3bc9a/zeroconf-0.146.1-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f26afa9cbc9e428315bc809a24862813ceca9d8b07faa7bb06dec1c4fb11bd61", size = 2097678 },
+    { url = "https://files.pythonhosted.org/packages/b6/5e/3b87f8e7083209ee5a66b083181692fb48b51badaad4a02047f0a2b944e3/zeroconf-0.146.1-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:bdcbb108e863db3b53d6cbfc38e2ef06a5c163705cd8de7de2822e4fa1d67b84", size = 2307312 },
+    { url = "https://files.pythonhosted.org/packages/72/ab/a23f273aff7f7d71a6f755a5d8d584f517653b88a215cca830bda8a5779c/zeroconf-0.146.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7c078f3df1fbe8086c43f1a9cc2fb5e8ca82463784590123e338b0ab488d7aff", size = 2297956 },
+    { url = "https://files.pythonhosted.org/packages/28/1b/42bcf3a2a76e3b135ec54448e66f98514b72b27d25465e4d707843e3bd3c/zeroconf-0.146.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:e8747576c96d41a438d3670679faf13682c5758c28e20b5873fbf6f118baf20d", size = 2152671 },
+    { url = "https://files.pythonhosted.org/packages/12/e3/60b25989309d0afceecff00256efd20a9c4399db0525f89071daf9437536/zeroconf-0.146.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0039e479cc4313161bf9631adf3491d1ad7fadc7524a085e4f2608ed6fe5cb23", size = 2495780 },
+    { url = "https://files.pythonhosted.org/packages/d6/18/59f25acd7f36a12ce2358a614a664c259b87bd2842bb28496db9930794d1/zeroconf-0.146.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0647951469d8e01cc8573cd97ee8b6d8b507f1c1178a5555e9897102a92e67c9", size = 2459360 },
+    { url = "https://files.pythonhosted.org/packages/98/3a/2e7c3afc58ece08f40277993686d261025275b09ddd30f63aa5dc645c710/zeroconf-0.146.1-cp313-cp313-win32.whl", hash = "sha256:4b223dc7ec958b94e437e2b4a7905721c2981f5283885bfad87206f87bd7596d", size = 1427495 },
+    { url = "https://files.pythonhosted.org/packages/3c/3c/2df619301c092089ec3942253ad504419569ec6f642605ee96f17f4b2f5c/zeroconf-0.146.1-cp313-cp313-win_amd64.whl", hash = "sha256:067920e9a7b946f280ee5266f18611500ab138b03a6389e7f1e4fa38ebe475f3", size = 1655851 },
+    { url = "https://files.pythonhosted.org/packages/b9/a6/3814aefa65861960250ff7c0be8e500e61e49ff32a93535e199846ea91ce/zeroconf-0.146.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:dedc82d4a3c61b7ce06fd681551a8abb30193ca94ce712570b2a94ccfb008b8b", size = 1645308 },
+    { url = "https://files.pythonhosted.org/packages/71/0c/a795cf312f167f8ac31e0f5b90500386f53b99f1d5c7fc4349403debb653/zeroconf-0.146.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:704e4795df4dd328fc774fc0024ac5702f5fffbe7a51f201135bca8ea1cb3857", size = 1542274 },
+    { url = "https://files.pythonhosted.org/packages/2a/31/5e3052e828d68c991230ec5456248cfef186a7837abd04a807e460f1ae1e/zeroconf-0.146.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24881185407da0d360bcc47649db46eefbac238dd692a5b54607404dde00961a", size = 1981259 },
+    { url = "https://files.pythonhosted.org/packages/21/32/135fd0b96a95fa49afe0a859e6eca3d603b18f5ecd33fe57f13159349a55/zeroconf-0.146.1-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f043c8dcd562fc17cb8e90a2c989331c824b517744e8886a02c1fb4b4fda0fde", size = 2100554 },
+    { url = "https://files.pythonhosted.org/packages/68/77/ee51d7f2b083cbb82dd7bc997d26ce11d7a09ad81028449fc6ba0a5082fd/zeroconf-0.146.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77b843c485cd7d52b801aa7790bd6821da9a992fdcfbfafc826e2892f04453fb", size = 2075621 },
+    { url = "https://files.pythonhosted.org/packages/21/13/24686743be4d816486aafb253e3d3dc242cf51c4b655058d29aa16bc2ea6/zeroconf-0.146.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c6a6a31e5395c39f7441adc7266f711c407e9d0a69dd972b4297248e29c95d5b", size = 1549293 },
 ]
 
 [[package]]


### PR DESCRIPTION
This is an automated update of the `uv.lock` file.

```
Using CPython 3.13.2 interpreter at: C:\hostedtoolcache\windows\Python\3.13.2\x64\python3.exe
Resolved 83 packages in 402ms
Updated aiohappyeyeballs v2.4.6 -> v2.5.0
Updated jinja2 v3.1.5 -> v3.1.6
Updated protobuf v5.29.3 -> v6.30.0
Updated pyright v1.1.395 -> v1.1.396
Updated zeroconf v0.145.1 -> v0.146.1
```