### PR TITLE
Fix Time float exceptions

### DIFF
--- a/raceinfo/heat_test.py
+++ b/raceinfo/heat_test.py
@@ -116,12 +116,12 @@ class TestHeat:
         """Test the place method."""
         heat = Heat(
             lanes=[
-                Lane(final_time=Time(150)),
-                Lane(final_time=Time(200)),
-                Lane(final_time=Time(150)),
+                Lane(final_time=Time("150")),
+                Lane(final_time=Time("200")),
+                Lane(final_time=Time("150")),
                 Lane(final_time=None),
-                Lane(final_time=Time(50), is_dq=True),
-                Lane(final_time=Time(100)),
+                Lane(final_time=Time("50"), is_dq=True),
+                Lane(final_time=Time("100")),
             ]
         )
         assert heat.place(1) == 2  # noqa: PLR2004
@@ -152,8 +152,8 @@ class TestHeat:
         """Test the resolve_times method."""
         heat = Heat(
             lanes=[
-                Lane(primary=Time(1.0)),
-                Lane(primary=Time(4.0)),
+                Lane(primary=Time("1.0")),
+                Lane(primary=Time("4.0")),
             ]
         )
 
@@ -161,8 +161,8 @@ class TestHeat:
             lane.final_time = lane.primary
 
         heat.resolve_times(assign_final_time)
-        assert heat.lane(1).final_time == Time(1.0)
-        assert heat.lane(2).final_time == Time(4.0)
+        assert heat.lane(1).final_time == Time("1.0")
+        assert heat.lane(2).final_time == Time("4.0")
         assert heat.lane(3).final_time is None
 
     def test_merge(self):
@@ -174,7 +174,7 @@ class TestHeat:
             meet_id="id-one",
             race=11,
             time_recorded=datetime.strptime("2025-01-01", "%Y-%m-%d"),
-            lanes=[Lane(name="one", primary=Time(100.00))],
+            lanes=[Lane(name="one", primary=Time("100.00"))],
         )
         heat2 = Heat(
             event="2",
@@ -183,7 +183,7 @@ class TestHeat:
             meet_id="id-two",
             race=12,
             time_recorded=datetime.strptime("2025-02-02", "%Y-%m-%d"),
-            lanes=[Lane(name="two", primary=Time(200.00))],
+            lanes=[Lane(name="two", primary=Time("200.00"))],
         )
         m1 = copy.deepcopy(heat1)
         m1.merge(heat2)
@@ -194,7 +194,7 @@ class TestHeat:
         assert m1.race == 11  # noqa: PLR2004
         assert m1.time_recorded == datetime.strptime("2025-01-01", "%Y-%m-%d")
         assert m1.lane(1).name == "two"
-        assert m1.lane(1).primary == Time(100.00)
+        assert m1.lane(1).primary == Time("100.00")
 
         m2 = copy.deepcopy(heat1)
         m2.merge(results_from=heat2)
@@ -205,7 +205,7 @@ class TestHeat:
         assert m2.race == 12  # noqa: PLR2004
         assert m2.time_recorded == datetime.strptime("2025-02-02", "%Y-%m-%d")
         assert m2.lane(1).name == "one"
-        assert m2.lane(1).primary == Time(200.00)
+        assert m2.lane(1).primary == Time("200.00")
 
     def test_sorting(self):
         """Test sorting of Heat objects."""
@@ -237,8 +237,8 @@ class TestHeat:
             description="d1",
             meet_id="id-one",
             lanes=[
-                Lane(name="one", primary=Time(100.00)),
-                Lane(name="two", primary=Time(200.00)),
+                Lane(name="one", primary=Time("100.00")),
+                Lane(name="two", primary=Time("200.00")),
             ],
         )
         # Identical is similar
@@ -254,7 +254,7 @@ class TestHeat:
         heat2.lane(1).primary = None
         check_heat_is_similar(heat1, heat2)
         # Different lanes are not similar
-        heat2.lane(1).primary = Time(999.00)
+        heat2.lane(1).primary = Time("999.00")
         with pytest.raises(ValueError):
             check_heat_is_similar(heat1, heat2, do_throw=True)
 

--- a/raceinfo/lane_test.py
+++ b/raceinfo/lane_test.py
@@ -88,7 +88,7 @@ class TestLaneValidation:
     def test_invalid_seed_time(self):
         """Invalid seed time raises ValueError."""
         with pytest.raises(ValueError):
-            Lane(seed_time=Time(-1.0))
+            Lane(seed_time=Time("-1.0"))
 
     def test_invalid_age(self):
         """Invalid age raises ValueError."""
@@ -98,22 +98,22 @@ class TestLaneValidation:
     def test_invalid_primary(self):
         """Invalid primary time raises ValueError."""
         with pytest.raises(ValueError):
-            Lane(primary=Time(-1.0))
+            Lane(primary=Time("-1.0"))
 
     def test_invalid_final_time(self):
         """Invalid final time raises ValueError."""
         with pytest.raises(ValueError):
-            Lane(primary=Time(1.0), final_time=Time(-1.0))
+            Lane(primary=Time("1.0"), final_time=Time("-1.0"))
 
     def test_invalid_backups(self):
         """Invalid backups raise ValueError."""
         with pytest.raises(ValueError):
-            Lane(backups=[Time(-1.0)])
+            Lane(backups=[Time("-1.0")])
 
     def test_invalid_splits(self):
         """Invalid splits raise ValueError."""
         with pytest.raises(ValueError):
-            Lane(splits=[[Time(-1.0)]])
+            Lane(splits=[[Time("-1.0")]])
 
 
 class TestLaneMerge:
@@ -125,12 +125,12 @@ class TestLaneMerge:
         return Lane(
             name="Alice",
             team="Apples",
-            seed_time=Time(1.0),
+            seed_time=Time("1.0"),
             age=7,
-            primary=Time(54.32),
-            final_time=Time(54.54),
-            backups=[Time(1.0), Time(2.0), Time(3.0)],
-            splits=[[Time(14.0)], [Time(15.0), Time(16.0)]],
+            primary=Time("54.32"),
+            final_time=Time("54.54"),
+            backups=[Time("1.0"), Time("2.0"), Time("3.0")],
+            splits=[[Time("14.0")], [Time("15.0"), Time("16.0")]],
             is_dq=True,
             is_empty=False,
         )
@@ -141,12 +141,12 @@ class TestLaneMerge:
         return Lane(
             name="Bob",
             team="Bananas",
-            seed_time=Time(2.0),
+            seed_time=Time("2.0"),
             age=8,
-            primary=Time(64.32),
-            final_time=Time(64.54),
-            backups=[Time(5.0), Time(6.0), Time(7.0)],
-            splits=[[Time(24.0)], [Time(25.0), Time(26.0)]],
+            primary=Time("64.32"),
+            final_time=Time("64.54"),
+            backups=[Time("5.0"), Time("6.0"), Time("7.0")],
+            splits=[[Time("24.0")], [Time("25.0"), Time("26.0")]],
             is_dq=False,
             is_empty=False,
         )
@@ -157,13 +157,13 @@ class TestLaneMerge:
         # Info from lane2
         assert lane1.name == "Bob"
         assert lane1.team == "Bananas"
-        assert lane1.seed_time == Time(2.0)
+        assert lane1.seed_time == Time("2.0")
         assert lane1.age == 8  # noqa: PLR2004
         # Results from lane1
-        assert lane1.primary == Time(54.32)
-        assert lane1.final_time == Time(54.54)
-        assert lane1.backups == [Time(1.0), Time(2.0), Time(3.0)]
-        assert lane1.splits == [[Time(14.0)], [Time(15.0), Time(16.0)]]
+        assert lane1.primary == Time("54.32")
+        assert lane1.final_time == Time("54.54")
+        assert lane1.backups == [Time("1.0"), Time("2.0"), Time("3.0")]
+        assert lane1.splits == [[Time("14.0")], [Time("15.0"), Time("16.0")]]
         assert lane1.is_dq is True
         assert lane1.is_empty is False
         # None values are merged
@@ -177,13 +177,13 @@ class TestLaneMerge:
         # Info from lane1
         assert lane1.name == "Alice"
         assert lane1.team == "Apples"
-        assert lane1.seed_time == Time(1.0)
+        assert lane1.seed_time == Time("1.0")
         assert lane1.age == 7  # noqa: PLR2004
         # Results from lane2
-        assert lane1.primary == Time(64.32)
-        assert lane1.final_time == Time(64.54)
-        assert lane1.backups == [Time(5.0), Time(6.0), Time(7.0)]
-        assert lane1.splits == [[Time(24.0)], [Time(25.0), Time(26.0)]]
+        assert lane1.primary == Time("64.32")
+        assert lane1.final_time == Time("64.54")
+        assert lane1.backups == [Time("5.0"), Time("6.0"), Time("7.0")]
+        assert lane1.splits == [[Time("24.0")], [Time("25.0"), Time("26.0")]]
         assert lane1.is_dq is False
         assert lane1.is_empty is False
         # None values are merged
@@ -206,20 +206,20 @@ class TestLaneSimilarity:
         lane1 = Lane(
             name="A",
             team="B",
-            seed_time=Time(1.0),
+            seed_time=Time("1.0"),
             age=7,
-            primary=Time(4.32),
-            final_time=Time(4.54),
+            primary=Time("4.32"),
+            final_time=Time("4.54"),
             is_dq=True,
             is_empty=False,
         )
         lane2 = Lane(
             name="A",
             team="B",
-            seed_time=Time(1.0),
+            seed_time=Time("1.0"),
             age=7,
-            primary=Time(4.32),
-            final_time=Time(4.54),
+            primary=Time("4.32"),
+            final_time=Time("4.54"),
             is_dq=True,
             is_empty=False,
         )
@@ -237,23 +237,23 @@ class TestLaneSimilarity:
     def test_similar_checks_splits(self):
         """Similarity checks splits."""
         # matching splits are similar
-        lane1 = Lane(splits=[[Time(1.0)], [Time(2.0), Time(3.0)]])
-        lane2 = Lane(splits=[[Time(1.0)], [Time(2.0), Time(3.0)]])
+        lane1 = Lane(splits=[[Time("1.0")], [Time("2.0"), Time("3.0")]])
+        lane2 = Lane(splits=[[Time("1.0")], [Time("2.0"), Time("3.0")]])
         check_lane_is_similar(lane1, lane2)
         check_lane_is_similar(lane2, lane1)
         # different splits are not similar
-        lane2.splits = [[Time(1.0)], [Time(2.0), Time(4.0)]]
+        lane2.splits = [[Time("1.0")], [Time("2.0"), Time("4.0")]]
         with pytest.raises(ValueError):
             check_lane_is_similar(lane1, lane2, do_throw=True)
         with pytest.raises(ValueError):
             check_lane_is_similar(lane2, lane1, do_throw=True)
         # different number of splits are not similar
-        lane2.splits = [[Time(1.0)], [Time(2.0)]]
+        lane2.splits = [[Time("1.0")], [Time("2.0")]]
         with pytest.raises(ValueError):
             check_lane_is_similar(lane1, lane2, do_throw=True)
         with pytest.raises(ValueError):
             check_lane_is_similar(lane2, lane1, do_throw=True)
-        lane2.splits = [[Time(1.0)], [Time(2.0), None]]
+        lane2.splits = [[Time("1.0")], [Time("2.0"), None]]
         with pytest.raises(ValueError):
             check_lane_is_similar(lane1, lane2, do_throw=True)
         with pytest.raises(ValueError):
@@ -272,18 +272,18 @@ class TestLaneSimilarity:
     def test_similar_checks_backups(self):
         """Similarity checks backups."""
         # matching backups are similar
-        lane1 = Lane(backups=[Time(1.0), Time(2.0), Time(3.0)])
-        lane2 = Lane(backups=[Time(1.0), Time(2.0), Time(3.0)])
+        lane1 = Lane(backups=[Time("1.0"), Time("2.0"), Time("3.0")])
+        lane2 = Lane(backups=[Time("1.0"), Time("2.0"), Time("3.0")])
         check_lane_is_similar(lane1, lane2)
         check_lane_is_similar(lane2, lane1)
         # different backups are not similar
-        lane2.backups = [Time(1.0), Time(2.0), Time(4.0)]
+        lane2.backups = [Time("1.0"), Time("2.0"), Time("4.0")]
         with pytest.raises(ValueError):
             check_lane_is_similar(lane1, lane2, do_throw=True)
         with pytest.raises(ValueError):
             check_lane_is_similar(lane2, lane1, do_throw=True)
         # different number of backups are not similar
-        lane2.backups = [Time(1.0), Time(2.0)]
+        lane2.backups = [Time("1.0"), Time("2.0")]
         with pytest.raises(ValueError):
             check_lane_is_similar(lane1, lane2, do_throw=True)
         with pytest.raises(ValueError):

--- a/raceinfo/time.py
+++ b/raceinfo/time.py
@@ -26,7 +26,7 @@ from typing import Literal
 
 # https://docs.python.org/3/library/decimal.html#signals
 # Raise decimal.FloatOperation when Decimal and float are improperly mixed
-decimal.DefaultContext.traps[decimal.FloatOperation] = True
+decimal.getcontext().traps[decimal.FloatOperation] = True
 
 Time = decimal.Decimal
 """A Time in seconds and hundredths of a second"""
@@ -160,7 +160,7 @@ def combine_times(times: list[Time | None]) -> Time | None:
     Decimal('200.00')
     >>> combine_times([Time(300), Time(100), Time(200), Time(400)])
     Decimal('250.00')
-    >>> combine_times([Time(10.25), Time(10.00)])
+    >>> combine_times([Time("10.25"), Time("10.00")])
     Decimal('10.12')
     """
     valid_times = [time for time in times if time is not None]

--- a/resolver.py
+++ b/resolver.py
@@ -143,7 +143,7 @@ def _get_candidate(raw_times: list[Time]) -> Time | None:
     Decimal('200.00')
     >>> _get_candidate([Time(300), Time(100), Time(200), Time(400)])
     Decimal('250.00')
-    >>> _get_candidate([Time(10.25), Time(10.00)])
+    >>> _get_candidate([Time("10.25"), Time("10.00")])
     Decimal('10.12')
     """
     num_times = len(raw_times)


### PR DESCRIPTION
- Enabled FloatOperation exception on Decimal (Time) type by modifying current context instead of default context.
- Fixed tests that weren't properly constructing Time types