### PR TITLE
Add macos build and attach screenshot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: uv run --locked --no-dev python build.py
 
-      - name: Save executable as artifact
+      - name: Save executable (macOS) as artifact
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -218,7 +218,7 @@ jobs:
           path: wahoo-results
           if-no-files-found: error
 
-      - name: Save executable as artifact
+      - name: Save executable (Windows) as artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -226,19 +226,20 @@ jobs:
           path: wahoo-results.exe
           if-no-files-found: error
 
-      - name: Grab screenshot
-        run: |
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            wahoo-results.exe --test screencap
-          else
-            ./wahoo-results --test screencap
-          fi
+      - name: Grab screenshot (macOS)
+        if: runner.os == 'macOS'
+        run: ./wahoo-results --test screenshot
+
+      - name: Grab screenshot (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: wahoo-results.exe --test screenshot
 
       - name: Upload screenshot
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-screenshot-${{ runner.os }}
-          path: screencap.png
+          path: screenshot-*.png
           if-no-files-found: error
 
   autotest:

--- a/main_window.py
+++ b/main_window.py
@@ -78,7 +78,7 @@ class View(ttk.Frame):
 
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
-        book = ttk.Notebook(self)
+        book = ttk.Notebook(self, name="tabs")
         book.grid(column=0, row=0, sticky="news")
         book.add(
             _configTab(book, self._vm), text="Configuration", underline=0, sticky="news"


### PR DESCRIPTION
This pull request introduces several enhancements to the build workflow and adds new functionality for capturing application screenshots in the `autotest.py` script. The most significant changes include adding support for multiple operating systems in the CI pipeline, implementing a screenshot capture feature, and updating the build process to handle OS-specific artifacts.

### Workflow Enhancements:
* Updated `.github/workflows/test.yml` to support a matrix build strategy for both macOS and Windows runners, enabling cross-platform testing.
* Added conditional steps for OS-specific tasks, such as installing UPX, saving artifacts, and running commands. For example, macOS and Windows now save their respective build artifacts separately. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R193) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R202-R243)
* Introduced steps to capture and upload screenshots during the build process, with support for both macOS and Windows environments.

### Screenshot Capture Feature:
* Added a `capture_widget` function in `autotest.py` to capture screenshots of Tkinter widgets using `PIL.ImageGrab`.
* Implemented a new `CaptureWindow` class in `autotest.py` to encapsulate the logic for capturing and saving application window screenshots.
* Extended the `build_scenario` function to support a new "screencap" test, which captures a screenshot and saves it to a file.

These changes improve the CI pipeline's flexibility and add valuable testing capabilities for visual verification of the application.